### PR TITLE
Use sets instead of arrays

### DIFF
--- a/dist/diffhtml.js
+++ b/dist/diffhtml.js
@@ -643,6 +643,9 @@ function make(node) {
   // Set a lowercased (normalized) version of the element's nodeName.
   entry.nodeName = node.nodeName.toLowerCase();
 
+  // Keep consistent with our internal HTML parser and set the nodeType.
+  entry.nodeType = node.nodeType;
+
   // If the element is a text node set the nodeValue.
   if (nodeType === 3) {
     entry.nodeValue = node.textContent;
@@ -675,7 +678,7 @@ function make(node) {
   var childNodesLength = childNodes.length;
 
   // If the element has child nodes, convert them all to virtual nodes.
-  if (node.nodeType !== 3 && childNodes) {
+  if (entry.nodeType !== 3 && childNodesLength) {
     for (var i = 0; i < childNodesLength; i++) {
       var newNode = make(childNodes[i]);
 
@@ -2396,8 +2399,8 @@ function createPool(name, opts) {
 
   var cache = {
     free: [],
-    allocated: [],
-    protected: [],
+    allocated: new Set(),
+    protected: new Set(),
     uuid: {}
   };
 
@@ -2410,58 +2413,42 @@ function createPool(name, opts) {
     cache: cache,
 
     get: function get() {
-      var obj = null;
-      var freeLength = cache.free.length;
-      var minusOne = freeLength - 1;
-
-      if (freeLength) {
-        obj = cache.free[minusOne];
-        cache.free.length = minusOne;
-      } else {
-        obj = fill();
-      }
-
-      cache.allocated.push(obj);
-
-      return obj;
+      var value = cache.free.pop() || fill();
+      cache.allocated.add(value);
+      return value;
     },
     protect: function protect(value) {
-      var idx = cache.allocated.indexOf(value);
+      cache.allocated.delete(value);
+      cache.protected.add(value);
 
-      // Move the value out of allocated, since we need to protect this from
-      // being free'd accidentally.
-      if (cache.protected.indexOf(value) === -1) {
-        cache.protected.push(idx === -1 ? value : cache.allocated.splice(idx, 1)[0]);
-      }
-
-      // If we're protecting an element object, push the uuid into a lookup
-      // table.
       if (name === 'elementObject') {
         cache.uuid[value.uuid] = value;
       }
     },
     unprotect: function unprotect(value) {
-      var idx = cache.protected.indexOf(value);
+      if (cache.protected.has(value)) {
+        cache.protected.delete(value);
+        cache.free.push(value);
+      }
 
-      if (idx !== -1) {
-        var obj = cache.protected.splice(idx, 1)[0];
-
-        if (obj) {
-          cache.free.push(obj);
-        }
-
-        if (name === 'elementObject') {
-          delete cache.uuid[value.uuid];
-        }
+      if (name === 'elementObject') {
+        delete cache.uuid[value.uuid];
       }
     },
     freeAll: function freeAll() {
       var freeLength = cache.free.length;
       var minusOne = freeLength - 1;
-      var reAlloc = cache.allocated.slice(0, size - minusOne);
+
+      // All of this could go away if we could figure out `Array.from` within
+      // a PhantomJS web-worker.
+      var reAlloc = [];
+      cache.allocated.forEach(function (v) {
+        return reAlloc.push(v);
+      });
+      reAlloc = reAlloc.slice(0, size - minusOne);
 
       cache.free.push.apply(cache.free, reAlloc);
-      cache.allocated.length = 0;
+      cache.allocated.clear();
 
       if (name === 'elementObject') {
         reAlloc.forEach(function (element) {
@@ -2470,10 +2457,8 @@ function createPool(name, opts) {
       }
     },
     free: function free(value) {
-      var idx = cache.allocated.indexOf(value);
-
       // Already freed.
-      if (idx === -1) {
+      if (!cache.allocated.has(value)) {
         return;
       }
 
@@ -2482,7 +2467,7 @@ function createPool(name, opts) {
         cache.free.push(value);
       }
 
-      cache.allocated.splice(idx, 1);
+      cache.allocated.delete(value);
     }
   };
 }

--- a/lib/util/memory.js
+++ b/lib/util/memory.js
@@ -57,7 +57,7 @@ export function cleanMemory(makeNode) {
   // Clean out unused elements.
   if (makeNode && makeNode.nodes) {
     for (let uuid in makeNode.nodes) {
-      if (!pools.elementObject.cache.uuid[uuid]) {
+      if (!pools.elementObject.cache.uuid.has(uuid)) {
         delete makeNode.nodes[uuid];
       }
     }

--- a/lib/util/pools.js
+++ b/lib/util/pools.js
@@ -17,7 +17,7 @@ export function createPool(name, opts) {
     free: [],
     allocated: new Set(),
     protected: new Set(),
-    uuid: {}
+    uuid: new Set(),
   };
 
   // Prime the cache with n objects.
@@ -39,7 +39,7 @@ export function createPool(name, opts) {
       cache.protected.add(value);
 
       if (name === 'elementObject') {
-        cache.uuid[value.uuid] = value;
+        cache.uuid.add(value.uuid);
       }
     },
 
@@ -50,26 +50,23 @@ export function createPool(name, opts) {
       }
 
       if (name === 'elementObject') {
-        delete cache.uuid[value.uuid];
+        cache.uuid.delete(value.uuid);
       }
     },
 
     freeAll() {
-      let freeLength = cache.free.length;
-      let minusOne = freeLength - 1;
-
       // All of this could go away if we could figure out `Array.from` within
       // a PhantomJS web-worker.
-      let reAlloc = [];
-      cache.allocated.forEach(v => reAlloc.push(v));
-      reAlloc = reAlloc.slice(0, size - minusOne);
+      cache.allocated.forEach(value => {
+        cache.free.push(value);
 
-      cache.free.push.apply(cache.free, reAlloc);
+        if (name === 'elementObject') {
+          cache.uuid.delete(value.uuid);
+        }
+      });
+
       cache.allocated.clear();
-
-      if (name === 'elementObject') {
-        reAlloc.forEach(element => delete cache.uuid[element.uuid]);
-      }
+      cache.free.length = size;
     },
 
     free(value) {

--- a/lib/util/pools.js
+++ b/lib/util/pools.js
@@ -15,8 +15,8 @@ export function createPool(name, opts) {
   var { size, fill } = opts;
   var cache = {
     free: [],
-    allocated: [],
-    protected: [],
+    allocated: new Set(),
+    protected: new Set(),
     uuid: {}
   };
 
@@ -29,64 +29,43 @@ export function createPool(name, opts) {
     cache,
 
     get() {
-      var obj = null;
-      var freeLength = cache.free.length;
-      var minusOne = freeLength - 1;
-
-      if (freeLength) {
-        obj = cache.free[minusOne];
-        cache.free.length = minusOne;
-      }
-      else {
-        obj = fill();
-      }
-
-      cache.allocated.push(obj);
-
-      return obj;
+      var value = cache.free.pop() || fill();
+      cache.allocated.add(value);
+      return value;
     },
 
     protect(value) {
-      let idx = cache.allocated.indexOf(value);
+      cache.allocated.delete(value);
+      cache.protected.add(value);
 
-      // Move the value out of allocated, since we need to protect this from
-      // being free'd accidentally.
-      if (cache.protected.indexOf(value) === -1) {
-        cache.protected.push(
-          idx === -1 ? value : cache.allocated.splice(idx, 1)[0]
-        );
-      }
-
-      // If we're protecting an element object, push the uuid into a lookup
-      // table.
       if (name === 'elementObject') {
         cache.uuid[value.uuid] = value;
       }
     },
 
     unprotect(value) {
-      let idx = cache.protected.indexOf(value);
+      if (cache.protected.has(value)) {
+        cache.protected.delete(value);
+        cache.free.push(value);
+      }
 
-      if (idx !== -1) {
-        let obj = cache.protected.splice(idx, 1)[0];
-
-        if (obj) {
-          cache.free.push(obj);
-        }
-
-        if (name === 'elementObject') {
-          delete cache.uuid[value.uuid];
-        }
+      if (name === 'elementObject') {
+        delete cache.uuid[value.uuid];
       }
     },
 
     freeAll() {
       let freeLength = cache.free.length;
       let minusOne = freeLength - 1;
-      let reAlloc = cache.allocated.slice(0, size - minusOne);
+
+      // All of this could go away if we could figure out `Array.from` within
+      // a PhantomJS web-worker.
+      let reAlloc = [];
+      cache.allocated.forEach(v => reAlloc.push(v));
+      reAlloc = reAlloc.slice(0, size - minusOne);
 
       cache.free.push.apply(cache.free, reAlloc);
-      cache.allocated.length = 0;
+      cache.allocated.clear();
 
       if (name === 'elementObject') {
         reAlloc.forEach(element => delete cache.uuid[element.uuid]);
@@ -94,17 +73,15 @@ export function createPool(name, opts) {
     },
 
     free(value) {
-      let idx = cache.allocated.indexOf(value);
-
       // Already freed.
-      if (idx === -1) { return; }
+      if (!cache.allocated.has(value)) { return; }
 
       // Only put back into the free queue if we're under the size.
       if (cache.free.length < size) {
         cache.free.push(value);
       }
 
-      cache.allocated.splice(idx, 1);
+      cache.allocated.delete(value);
     }
   };
 }

--- a/test/integration/memory.js
+++ b/test/integration/memory.js
@@ -14,9 +14,9 @@ describe('Integration: Memory management', function() {
 
   it('can allocate/deallocate uuids', function() {
     diff.innerHTML(this.fixture, '<p></p>');
-    assert.equal(Object.keys(pools.elementObject.cache.uuid).length, 2);
+    assert.equal(pools.elementObject.cache.uuid.size, 2);
 
     diff.innerHTML(this.fixture, '');
-    assert.equal(Object.keys(pools.elementObject.cache.uuid).length, 1);
+    assert.equal(pools.elementObject.cache.uuid.size, 1);
   });
 });

--- a/test/util/validateMemory.js
+++ b/test/util/validateMemory.js
@@ -11,7 +11,7 @@ export default function validateMemory() {
   assert.equal(pools.elementObject.cache.allocated.size, 0,
     'Should not leave leftover allocations');
 
-  assert.equal(Object.keys(pools.elementObject.cache.uuid).length, 0,
+  assert.equal(pools.elementObject.cache.uuid.size, 0,
     'All UUIDs should be unprotected');
 
   assert.equal(Object.keys(makeNode.nodes).length, 0,

--- a/test/util/validateMemory.js
+++ b/test/util/validateMemory.js
@@ -5,10 +5,10 @@ import makeNode from '../../lib/node/make';
  * Validates that the memory has been successfully cleaned per render.
  */
 export default function validateMemory() {
-  assert.equal(pools.elementObject.cache.protected.length, 0,
+  assert.equal(pools.elementObject.cache.protected.size, 0,
     'Should not leave leftover protected elements');
 
-  assert.equal(pools.elementObject.cache.allocated.length, 0,
+  assert.equal(pools.elementObject.cache.allocated.size, 0,
     'Should not leave leftover allocations');
 
   assert.equal(Object.keys(pools.elementObject.cache.uuid).length, 0,


### PR DESCRIPTION
This greatly improves the object pooling performance. No longer do we need to worry about checking `indexOf` on giant arrays.