### PR TITLE
Improves support for ShadowDOM, DocumentFragment, and is attribute for type extensions

### DIFF
--- a/dist/diffhtml.js
+++ b/dist/diffhtml.js
@@ -492,40 +492,43 @@ function enableProllyfill() {
     }
   });
 
-  // Allows a developer to set the `innerHTML` of an element.
-  Object.defineProperty(Element.prototype, 'diffInnerHTML', {
-    configurable: true,
+  // Exposes the API into the Element, ShadowDOM, and DocumentFragment
+  // constructors.
+  [typeof Element !== 'undefined' ? Element : undefined, typeof HTMLElement !== 'undefined' ? HTMLElement : undefined, typeof ShadowRoot !== 'undefined' ? ShadowRoot : undefined, typeof DocumentFragment !== 'undefined' ? DocumentFragment : undefined].filter(Boolean).forEach(function (Ctor) {
+    Object.defineProperty(Ctor.prototype, 'diffInnerHTML', {
+      configurable: true,
 
-    set: function set(newHTML) {
-      innerHTML(this, newHTML);
-    }
-  });
+      set: function set(newHTML) {
+        innerHTML(this, newHTML);
+      }
+    });
 
-  // Allows a developer to set the `outerHTML` of an element.
-  Object.defineProperty(Element.prototype, 'diffOuterHTML', {
-    configurable: true,
+    // Allows a developer to set the `outerHTML` of an element.
+    Object.defineProperty(Ctor.prototype, 'diffOuterHTML', {
+      configurable: true,
 
-    set: function set(newHTML) {
-      outerHTML(this, newHTML);
-    }
-  });
+      set: function set(newHTML) {
+        outerHTML(this, newHTML);
+      }
+    });
 
-  // Allows a developer to diff the current element with a new element.
-  Object.defineProperty(Element.prototype, 'diffElement', {
-    configurable: true,
+    // Allows a developer to diff the current element with a new element.
+    Object.defineProperty(Ctor.prototype, 'diffElement', {
+      configurable: true,
 
-    value: function value(newElement, options) {
-      element(this, newElement, options);
-    }
-  });
+      value: function value(newElement, options) {
+        element(this, newElement, options);
+      }
+    });
 
-  // Releases the retained memory and worker instance.
-  Object.defineProperty(Element.prototype, 'diffRelease', {
-    configurable: true,
+    // Releases the retained memory and worker instance.
+    Object.defineProperty(Ctor.prototype, 'diffRelease', {
+      configurable: true,
 
-    value: function value(newElement) {
-      (0, _release2.default)(this);
-    }
+      value: function value() {
+        (0, _release2.default)(this);
+      }
+    });
   });
 
   // Polyfill in the `registerElement` method if it doesn't already exist. This
@@ -608,8 +611,16 @@ function enableProllyfill() {
       documentElement.removeEventListener('renderComplete', render);
     });
 
+    //var descriptor = makeNode(documentElement);
+
+    // Lock the document element before running.
+    //protectElement(descriptor);
+
     // Diff the entire document on activation of the prollyfill.
     documentElement.diffOuterHTML = documentElement.outerHTML;
+
+    // Unprotect the element afterwards.
+    //unprotectElement(descriptor, makeNode);
 
     // Remove the load event listener, since it's complete.
     window.removeEventListener('load', activateComponents);
@@ -650,11 +661,10 @@ make.nodes = {};
  * @return
  */
 function make(node) {
-  // Default the nodeType to Element (1).
-  var nodeType = 'nodeType' in node ? node.nodeType : 1;
+  var nodeType = node.nodeType;
 
-  // Ignore attribute, comment, and CDATA nodes.
-  if (nodeType === 2 || nodeType === 4 || nodeType === 8) {
+  // Whitelist: Elements, TextNodes, and Shadow Root.
+  if (nodeType !== 1 && nodeType !== 3 && nodeType !== 11) {
     return false;
   }
 
@@ -667,9 +677,6 @@ function make(node) {
 
   // Set a lowercased (normalized) version of the element's nodeName.
   entry.nodeName = node.nodeName.toLowerCase();
-
-  // Keep consistent with our internal HTML parser and set the nodeType.
-  entry.nodeType = node.nodeType;
 
   // If the element is a text node set the nodeValue.
   if (nodeType === 3) {
@@ -703,7 +710,7 @@ function make(node) {
   var childNodesLength = childNodes.length;
 
   // If the element has child nodes, convert them all to virtual nodes.
-  if (entry.nodeType !== 3 && childNodesLength) {
+  if (nodeType !== 3 && childNodesLength) {
     for (var i = 0; i < childNodesLength; i++) {
       var newNode = make(childNodes[i]);
 
@@ -720,15 +727,13 @@ function make(node) {
     });
   }
 
-  if (_custom.components[entry.nodeName]) {
-    // Reset the prototype chain for this element. Upgrade will return `true`
-    // if the element was upgraded for the first time. This is useful so we
-    // don't end up in a loop when working with the same element.
-    if ((0, _custom.upgrade)(entry.nodeName, node, entry)) {
-      // If the Node is in the DOM, trigger attached callback.
-      if (node.parentNode && node.attachedCallback) {
-        node.attachedCallback();
-      }
+  // Reset the prototype chain for this element. Upgrade will return `true`
+  // if the element was upgraded for the first time. This is useful so we
+  // don't end up in a loop when working with the same element.
+  if ((0, _custom.upgrade)(entry.nodeName, node, entry)) {
+    // If the Node is in the DOM, trigger attached callback.
+    if (node.parentNode && node.attachedCallback) {
+      node.attachedCallback();
     }
   }
 
@@ -1440,7 +1445,7 @@ function process(element, patches) {
     // Remove the entire Node. Only does something if the Node has a parent
     // element.
     else if (patch.__do__ === sync.REMOVE_ENTIRE_ELEMENT) {
-        var detachPromises = transition.makePromises('detached', [patch.elemnt]);
+        var detachPromises = transition.makePromises('detached', [patch.element]);
 
         if (patch.element.parentNode) {
           triggerTransition('detached', detachPromises, function (promises) {
@@ -1706,6 +1711,12 @@ exports.makePromises = makePromises;
 
 var _custom = _dereq_('./element/custom');
 
+var _make = _dereq_('./node/make');
+
+var _make2 = _interopRequireDefault(_make);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
 var slice = Array.prototype.slice;
 var forEach = Array.prototype.forEach;
 var concat = Array.prototype.concat;
@@ -1812,6 +1823,11 @@ var fnSignatures = {
       return function (cb) {
         return cb(el, oldVal, newVal);
       };
+    },
+    customElementsFn: function customElementsFn(el, oldVal, newVal) {
+      return function (cb) {
+        return cb.call(el, oldVal, newVal);
+      };
     }
   }
 };
@@ -1900,15 +1916,35 @@ function triggerLifecycleEvent(stateName, args, elements) {
 
   for (var i = 0; i < elements.length; i++) {
     var element = elements[i];
+    var isTextNode = element.nodeType === 3;
+    var nodeName = element.nodeName.toLowerCase();
+    var descriptor = (0, _make2.default)(element);
 
-    if (element) {
-      var customElement = _custom.components[element.nodeName.toLowerCase()] || empty;
-      var customElementMethodName = stateName + 'Callback';
+    // Value of the `is` attribute, if it exists.
+    var isAttr = null;
 
-      // Call the associated CustomElement's lifecycle callback, if it exists.
-      if (customElement.prototype[customElementMethodName]) {
-        customElementFn.apply(null, args)(customElement.prototype[customElementMethodName].bind(element));
-      }
+    // Check for the `is` attribute. It has a known bug where it cannot be
+    // applied dynamically.
+    if (!_custom.components[nodeName] && Array.isArray(descriptor.attributes)) {
+      descriptor.attributes.some(function (attr, idx) {
+        if (attr.name === 'is') {
+          isAttr = attr.value;
+          return true;
+        }
+      });
+    }
+
+    // Hack around the `is` attribute being unable to be set dynamically.
+    if (isAttr && _custom.components[isAttr]) {
+      nodeName = isAttr;
+    }
+
+    var customElement = _custom.components[nodeName] || empty;
+    var customElementMethodName = stateName + 'Callback';
+
+    // Call the associated CustomElement's lifecycle callback, if it exists.
+    if (customElement.prototype[customElementMethodName]) {
+      customElementFn.apply(null, args)(customElement.prototype[customElementMethodName].bind(element));
     }
   }
 }
@@ -1928,6 +1964,7 @@ function makePromises(stateName) {
   // Ensure elements is always an array.
   var elements = slice.call(args[0]);
 
+  // Triggers the custom element callback.
   triggerLifecycleEvent(stateName, args.slice(1), elements);
 
   // Accepts the local Array of promises to use.
@@ -1936,7 +1973,7 @@ function makePromises(stateName) {
   };
 }
 
-},{"./element/custom":1}],14:[function(_dereq_,module,exports){
+},{"./element/custom":1,"./node/make":6}],14:[function(_dereq_,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -1948,12 +1985,13 @@ var element = document.createElement('div');
 /**
  * Decodes HTML strings.
  *
- * @see http://stackoverflow.com/a/13091266
+ * @see http://stackoverflow.com/a/5796718
  * @param stringing
  * @return unescaped HTML
  */
 function decodeEntities(string) {
   element.innerHTML = string;
+
   return element.textContent;
 }
 
@@ -1988,9 +2026,9 @@ var attributeObject = pools.attributeObject;
  * @return element
  */
 function protectElement(element) {
-  pools.elementObject.protect(element);
+  elementObject.protect(element);
 
-  element.attributes.forEach(pools.attributeObject.protect, pools.attributeObject);
+  element.attributes.forEach(attributeObject.protect, attributeObject);
 
   if (element.childNodes) {
     element.childNodes.forEach(protectElement);
@@ -2494,6 +2532,7 @@ function initializePools(COUNT) {
 
     fill: function fill() {
       return {
+        nodeName: '',
         uuid: uuid(),
         childNodes: [],
         attributes: []
@@ -2635,6 +2674,17 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 // Tests if the browser has support for the `Worker` API.
 var hasWorker = exports.hasWorker = typeof Worker === 'function';
 
+// Find all the coverage statements and expressions.
+var COV_EXP = /__cov_([^\+\+]*)\+\+/gi;
+
+/**
+ * Awful hack to remove `__cov` lines from the source before sending over to
+ * the worker. Only useful while testing.
+ */
+function filterOutCoverage(string) {
+  return string.replace(COV_EXP, 'null');
+}
+
 /**
  * Creates a new Web Worker per element that will be diffed. Allows multiple
  * concurrent diffing operations to occur simultaneously, leveraging the
@@ -2655,7 +2705,7 @@ var hasWorker = exports.hasWorker = typeof Worker === 'function';
 function create() {
   var worker = null;
   var workerBlob = null;
-  var workerSource = '\n    // Reusable Array methods.\n    var slice = Array.prototype.slice;\n    var filter = Array.prototype.filter;\n\n    // Add a namespace to attach pool methods to.\n    var pools = {};\n    var nodes = 0;\n    var REMOVE_ELEMENT_CHILDREN = -2;\n    var REMOVE_ENTIRE_ELEMENT = -1;\n    var MODIFY_ELEMENT = 1;\n    var MODIFY_ATTRIBUTE = 2;\n    var CHANGE_TEXT = 3;\n\n    ' + _uuid2.default + ';\n\n    // Add the ability to protect elements from free\'d memory.\n    ' + _memory.protectElement + ';\n    ' + _memory.unprotectElement + ';\n    ' + _memory.cleanMemory + ';\n\n    // Add in pool manipulation methods.\n    ' + _pools.createPool + ';\n    ' + _pools.initializePools + ';\n\n    initializePools(' + _pools.count + ');\n\n    // Short hands for pool access.\n    var elementObject = pools.elementObject;\n    var attributeObject = pools.attributeObject;\n\n    // Add in Node manipulation.\n    var syncNode = ' + _sync2.default + ';\n    var makeNode = ' + _make2.default + ';\n\n    // Add in the ability to parseHTML.\n    ' + _parser.parseHTML + ';\n\n    var makeParser = ' + _parser.makeParser + ';\n    var parser = makeParser();\n\n    // Add in the worker source.\n    ' + _source2.default + ';\n\n    // Metaprogramming up this worker call.\n    startup(self);\n  ';
+  var workerSource = filterOutCoverage('\n    // Reusable Array methods.\n    var slice = Array.prototype.slice;\n    var filter = Array.prototype.filter;\n\n    // Add a namespace to attach pool methods to.\n    var pools = {};\n    var nodes = 0;\n    var REMOVE_ELEMENT_CHILDREN = -2;\n    var REMOVE_ENTIRE_ELEMENT = -1;\n    var MODIFY_ELEMENT = 1;\n    var MODIFY_ATTRIBUTE = 2;\n    var CHANGE_TEXT = 3;\n\n    ' + _uuid2.default + ';\n\n    // Add the ability to protect elements from free\'d memory.\n    ' + _memory.protectElement + ';\n    ' + _memory.unprotectElement + ';\n    ' + _memory.cleanMemory + ';\n\n    // Add in pool manipulation methods.\n    ' + _pools.createPool + ';\n    ' + _pools.initializePools + ';\n\n    initializePools(' + _pools.count + ');\n\n    // Short hands for pool access.\n    var elementObject = pools.elementObject;\n    var attributeObject = pools.attributeObject;\n\n    // Add in Node manipulation.\n    var syncNode = ' + _sync2.default + ';\n    var makeNode = ' + _make2.default + ';\n\n    // Add in the ability to parseHTML.\n    ' + _parser.parseHTML + ';\n\n    var makeParser = ' + _parser.makeParser + ';\n    var parser = makeParser();\n\n    // Add in the worker source.\n    ' + _source2.default + ';\n\n    // Metaprogramming up this worker call.\n    startup(self);\n  ');
 
   // Set up a WebWorker if available.
   if (hasWorker) {

--- a/dist/diffhtml.js
+++ b/dist/diffhtml.js
@@ -291,6 +291,12 @@ var _custom = _dereq_('./element/custom');
 
 var _tree = _dereq_('./node/tree');
 
+var _make = _dereq_('./node/make');
+
+var _make2 = _interopRequireDefault(_make);
+
+var _memory = _dereq_('./util/memory');
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 /**
@@ -598,12 +604,17 @@ function enableProllyfill() {
       return window.removeEventListener('load', activateComponents);
     }
 
+    var descriptor = (0, _make2.default)(documentElement);
+
     // After the initial render, clean up the resources, no point in lingering.
     documentElement.addEventListener('renderComplete', function render() {
       var elementMeta = _tree.TreeCache.get(documentElement) || {};
 
       // Release resources allocated to the element.
       if (!elementMeta.isRendering) {
+
+        // Unprotect after the activation is complete.
+        (0, _memory.unprotectElement)(descriptor, _make2.default);
         documentElement.diffRelease(documentElement);
       }
 
@@ -611,16 +622,11 @@ function enableProllyfill() {
       documentElement.removeEventListener('renderComplete', render);
     });
 
-    //var descriptor = makeNode(documentElement);
-
-    // Lock the document element before running.
-    //protectElement(descriptor);
+    // Protect the documentElement before applying the changes.
+    (0, _memory.protectElement)(descriptor);
 
     // Diff the entire document on activation of the prollyfill.
     documentElement.diffOuterHTML = documentElement.outerHTML;
-
-    // Unprotect the element afterwards.
-    //unprotectElement(descriptor, makeNode);
 
     // Remove the load event listener, since it's complete.
     window.removeEventListener('load', activateComponents);
@@ -636,7 +642,7 @@ function enableProllyfill() {
   }
 }
 
-},{"./element/custom":1,"./errors":4,"./node/patch":7,"./node/release":8,"./node/tree":10,"./transitions":13}],6:[function(_dereq_,module,exports){
+},{"./element/custom":1,"./errors":4,"./node/make":6,"./node/patch":7,"./node/release":8,"./node/tree":10,"./transitions":13,"./util/memory":15}],6:[function(_dereq_,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {

--- a/examples/transitions/script.html
+++ b/examples/transitions/script.html
@@ -16,8 +16,13 @@
     var textarea = document.querySelector('textarea');
 
     diff.addTransitionState('textChanged', function(el, old, current) {
-      if (el.matches('script')) {
-        eval(el.textContent);
+      if (el.parentNode.matches('script')) {
+        try {
+          eval(current);
+        }
+        catch (ex) {
+          console.log('Unable to evaluate the script');
+        }
       }
     });
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -54,4 +54,3 @@ module.exports = function(config) {
     ]
   });
 };
-

--- a/lib/index.js
+++ b/lib/index.js
@@ -205,40 +205,48 @@ export function enableProllyfill() {
     }
   });
 
-  // Allows a developer to set the `innerHTML` of an element.
-  Object.defineProperty(Element.prototype, 'diffInnerHTML', {
-    configurable: true,
+  // Exposes the API into the Element, ShadowDOM, and DocumentFragment
+  // constructors.
+  [
+    typeof Element !== 'undefined' ? Element : undefined,
+    typeof HTMLElement !== 'undefined' ? HTMLElement : undefined,
+    typeof ShadowRoot !== 'undefined' ? ShadowRoot : undefined,
+    typeof DocumentFragment !== 'undefined' ? DocumentFragment : undefined,
+  ].filter(Boolean).forEach(Ctor => {
+    Object.defineProperty(Ctor.prototype, 'diffInnerHTML', {
+      configurable: true,
 
-    set(newHTML) {
-      innerHTML(this, newHTML);
-    }
-  });
+      set(newHTML) {
+        innerHTML(this, newHTML);
+      }
+    });
 
-  // Allows a developer to set the `outerHTML` of an element.
-  Object.defineProperty(Element.prototype, 'diffOuterHTML', {
-    configurable: true,
+    // Allows a developer to set the `outerHTML` of an element.
+    Object.defineProperty(Ctor.prototype, 'diffOuterHTML', {
+      configurable: true,
 
-    set(newHTML) {
-      outerHTML(this, newHTML);
-    }
-  });
+      set(newHTML) {
+        outerHTML(this, newHTML);
+      }
+    });
 
-  // Allows a developer to diff the current element with a new element.
-  Object.defineProperty(Element.prototype, 'diffElement', {
-    configurable: true,
+    // Allows a developer to diff the current element with a new element.
+    Object.defineProperty(Ctor.prototype, 'diffElement', {
+      configurable: true,
 
-    value(newElement, options) {
-      element(this, newElement, options);
-    }
-  });
+      value(newElement, options) {
+        element(this, newElement, options);
+      }
+    });
 
-  // Releases the retained memory and worker instance.
-  Object.defineProperty(Element.prototype, 'diffRelease', {
-    configurable: true,
+    // Releases the retained memory and worker instance.
+    Object.defineProperty(Ctor.prototype, 'diffRelease', {
+      configurable: true,
 
-    value(newElement) {
-      releaseNode(this);
-    }
+      value() {
+        releaseNode(this);
+      }
+    });
   });
 
   // Polyfill in the `registerElement` method if it doesn't already exist. This
@@ -329,11 +337,12 @@ export function enableProllyfill() {
   };
 
   // If the document has already loaded, immediately activate the components.
-  if (document.readyState === 'complete') { activateComponents(); }
+  if (document.readyState === 'complete') {
+    activateComponents();
+  }
   else {
     // This section will automatically parse out your entire page to ensure all
     // custom elements are hooked into.
     window.addEventListener('load', activateComponents);
   }
-
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,8 @@ import releaseNode from './node/release';
 import { states } from './transitions';
 import { components } from './element/custom';
 import { TreeCache } from './node/tree';
+import makeNode from './node/make';
+import { unprotectElement, protectElement } from './util/memory';
 
 import { TransitionStateError, DOMException } from './errors';
 // Export the custom Error constructors so that instanceof checks can be made
@@ -316,18 +318,26 @@ export function enableProllyfill() {
       return window.removeEventListener('load', activateComponents);
     }
 
+    var descriptor = makeNode(documentElement);
+
     // After the initial render, clean up the resources, no point in lingering.
     documentElement.addEventListener('renderComplete', function render() {
       var elementMeta = TreeCache.get(documentElement) || {};
 
       // Release resources allocated to the element.
       if (!elementMeta.isRendering) {
+
+        // Unprotect after the activation is complete.
+        unprotectElement(descriptor, makeNode);
         documentElement.diffRelease(documentElement);
       }
 
       // Remove this event listener.
       documentElement.removeEventListener('renderComplete', render);
     });
+
+    // Protect the documentElement before applying the changes.
+    protectElement(descriptor);
 
     // Diff the entire document on activation of the prollyfill.
     documentElement.diffOuterHTML = documentElement.outerHTML;

--- a/lib/node/make.js
+++ b/lib/node/make.js
@@ -14,11 +14,10 @@ make.nodes = {};
  * @return
  */
 export default function make(node) {
-  // Default the nodeType to Element (1).
-  let nodeType = 'nodeType' in node ? node.nodeType : 1;
+  let nodeType = node.nodeType;
 
-  // Ignore attribute, comment, and CDATA nodes.
-  if (nodeType === 2 || nodeType === 4 || nodeType === 8) {
+  // Whitelist: Elements, TextNodes, and Shadow Root.
+  if (nodeType !== 1 && nodeType !== 3 && nodeType !== 11) {
     return false;
   }
 
@@ -31,9 +30,6 @@ export default function make(node) {
 
   // Set a lowercased (normalized) version of the element's nodeName.
   entry.nodeName = node.nodeName.toLowerCase();
-
-  // Keep consistent with our internal HTML parser and set the nodeType.
-  entry.nodeType = node.nodeType;
 
   // If the element is a text node set the nodeValue.
   if (nodeType === 3) {
@@ -67,7 +63,7 @@ export default function make(node) {
   let childNodesLength = childNodes.length;
 
   // If the element has child nodes, convert them all to virtual nodes.
-  if (entry.nodeType !== 3 && childNodesLength) {
+  if (nodeType !== 3 && childNodesLength) {
     for (let i = 0; i < childNodesLength; i++) {
       let newNode = make(childNodes[i]);
 
@@ -84,15 +80,13 @@ export default function make(node) {
     });
   }
 
-  if (components[entry.nodeName]) {
-    // Reset the prototype chain for this element. Upgrade will return `true`
-    // if the element was upgraded for the first time. This is useful so we
-    // don't end up in a loop when working with the same element.
-    if (upgrade(entry.nodeName, node, entry)) {
-      // If the Node is in the DOM, trigger attached callback.
-      if (node.parentNode && node.attachedCallback) {
-        node.attachedCallback();
-      }
+  // Reset the prototype chain for this element. Upgrade will return `true`
+  // if the element was upgraded for the first time. This is useful so we
+  // don't end up in a loop when working with the same element.
+  if (upgrade(entry.nodeName, node, entry)) {
+    // If the Node is in the DOM, trigger attached callback.
+    if (node.parentNode && node.attachedCallback) {
+      node.attachedCallback();
     }
   }
 

--- a/lib/patches/process.js
+++ b/lib/patches/process.js
@@ -117,7 +117,7 @@ export default function process(element, patches) {
     // Remove the entire Node. Only does something if the Node has a parent
     // element.
     else if (patch.__do__ === sync.REMOVE_ENTIRE_ELEMENT) {
-      let detachPromises = transition.makePromises('detached', [patch.elemnt]);
+      let detachPromises = transition.makePromises('detached', [patch.element]);
 
       if (patch.element.parentNode) {
         triggerTransition('detached', detachPromises, promises => {

--- a/lib/transitions.js
+++ b/lib/transitions.js
@@ -1,4 +1,5 @@
 import { components } from './element/custom';
+import makeNode from './node/make';
 
 var slice = Array.prototype.slice;
 var forEach = Array.prototype.forEach;
@@ -75,7 +76,8 @@ var fnSignatures = {
   },
 
   textChanged: {
-    mapFn: (el, oldVal, newVal) => cb => cb(el, oldVal, newVal)
+    mapFn: (el, oldVal, newVal) => cb => cb(el, oldVal, newVal),
+    customElementsFn: (el, oldVal, newVal) => cb => cb.call(el, oldVal, newVal)
   }
 };
 
@@ -167,17 +169,37 @@ function triggerLifecycleEvent(stateName, args, elements) {
 
   for (let i = 0; i < elements.length; i++) {
     let element = elements[i];
+    let isTextNode = element.nodeType === 3;
+    let nodeName = element.nodeName.toLowerCase();
+    let descriptor = makeNode(element);
 
-    if (element) {
-      let customElement = components[element.nodeName.toLowerCase()] || empty;
-      let customElementMethodName = `${stateName}Callback`;
+    // Value of the `is` attribute, if it exists.
+    let isAttr = null;
 
-      // Call the associated CustomElement's lifecycle callback, if it exists.
-      if (customElement.prototype[customElementMethodName]) {
-        customElementFn.apply(null, args)(
-          customElement.prototype[customElementMethodName].bind(element)
-        );
-      }
+    // Check for the `is` attribute. It has a known bug where it cannot be
+    // applied dynamically.
+    if (!components[nodeName] && Array.isArray(descriptor.attributes)) {
+      descriptor.attributes.some((attr, idx) => {
+        if (attr.name === 'is') {
+          isAttr = attr.value;
+          return true;
+        }
+      });
+    }
+
+    // Hack around the `is` attribute being unable to be set dynamically.
+    if (isAttr && components[isAttr]) {
+      nodeName = isAttr;
+    }
+
+    let customElement = components[nodeName] || empty;
+    let customElementMethodName = `${stateName}Callback`;
+
+    // Call the associated CustomElement's lifecycle callback, if it exists.
+    if (customElement.prototype[customElementMethodName]) {
+      customElementFn.apply(null, args)(
+        customElement.prototype[customElementMethodName].bind(element)
+      );
     }
   }
 }
@@ -193,6 +215,7 @@ export function makePromises(stateName, ...args) {
   // Ensure elements is always an array.
   var elements = slice.call(args[0]);
 
+  // Triggers the custom element callback.
   triggerLifecycleEvent(stateName, args.slice(1), elements);
 
   // Accepts the local Array of promises to use.

--- a/lib/util/entities.js
+++ b/lib/util/entities.js
@@ -3,11 +3,12 @@ let element = document.createElement('div');
 /**
  * Decodes HTML strings.
  *
- * @see http://stackoverflow.com/a/13091266
+ * @see http://stackoverflow.com/a/5796718
  * @param stringing
  * @return unescaped HTML
  */
 export function decodeEntities(string) {
   element.innerHTML = string;
+
   return element.textContent;
 }

--- a/lib/util/memory.js
+++ b/lib/util/memory.js
@@ -14,10 +14,9 @@ var attributeObject = pools.attributeObject;
  * @return element
  */
 export function protectElement(element) {
-  pools.elementObject.protect(element);
+  elementObject.protect(element);
 
-  element.attributes.forEach(pools.attributeObject.protect,
-    pools.attributeObject);
+  element.attributes.forEach(attributeObject.protect, attributeObject);
 
   if (element.childNodes) {
     element.childNodes.forEach(protectElement);

--- a/lib/util/parser.js
+++ b/lib/util/parser.js
@@ -29,7 +29,8 @@ export function makeParser() {
   var kMarkupPattern =
     /<!--[^]*?(?=-->)-->|<(\/?)([a-z\-][a-z0-9\-]*)\s*([^>]*?)(\/?)>/ig;
 
-  var kAttributePattern = /\b(id|class)\s*(=\s*("([^"]+)"|'([^']+)'|(\S+)))?/ig;
+  var kAttributePattern =
+    /\b(id|class)\s*(=\s*("([^"]+)"|'([^']+)'|(\S+)))?/ig;
 
   var reAttrPattern =
     /\b([a-z][a-z0-9\-]*)\s*(=\s*("([^"]+)"|'([^']+)'|(\S+)))?/ig;

--- a/lib/util/pools.js
+++ b/lib/util/pools.js
@@ -68,6 +68,7 @@ export function initializePools(COUNT) {
 
     fill() {
       return {
+        nodeName: '',
         uuid: uuid(),
         childNodes: [],
         attributes: []

--- a/lib/worker/create.js
+++ b/lib/worker/create.js
@@ -10,6 +10,17 @@ import source from './source';
 // Tests if the browser has support for the `Worker` API.
 export var hasWorker = typeof Worker === 'function';
 
+// Find all the coverage statements and expressions.
+const COV_EXP = /__cov_([^\+\+]*)\+\+/gi;
+
+/**
+ * Awful hack to remove `__cov` lines from the source before sending over to
+ * the worker. Only useful while testing.
+ */
+function filterOutCoverage(string) {
+  return string.replace(COV_EXP, 'null');
+}
+
 /**
  * Creates a new Web Worker per element that will be diffed. Allows multiple
  * concurrent diffing operations to occur simultaneously, leveraging the
@@ -30,7 +41,7 @@ export var hasWorker = typeof Worker === 'function';
 export function create() {
   let worker = null;
   let workerBlob = null;
-  let workerSource = `
+  let workerSource = filterOutCoverage(`
     // Reusable Array methods.
     var slice = Array.prototype.slice;
     var filter = Array.prototype.filter;
@@ -76,7 +87,7 @@ export function create() {
 
     // Metaprogramming up this worker call.
     startup(self);
-  `;
+  `);
 
   // Set up a WebWorker if available.
   if (hasWorker) {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "browserify -t [ babelify --presets [ es2015 ] ] -s diff lib/index.js | derequire > dist/diffhtml.js",
     "watch": "watchify -t [ babelify --presets [ es2015 ] ] -s diff lib/index.js -o 'derequire > dist/diffhtml.js' -v",
     "jshint": "jshint lib/**/*.js",
-    "test": "npm run jshint && karma start --single-run"
+    "karma": "karma start",
+    "test": "npm run jshint && npm run karma -- --single-run"
   },
   "devDependencies": {
     "babel-core": "^6.5.2",

--- a/test/integration/basics.js
+++ b/test/integration/basics.js
@@ -247,6 +247,36 @@ describe('Integration: Basics', function() {
     });
   });
 
+  describe('DocumentFragment', function() {
+    it('can diff elements into a fragment', function() {
+      var fragment = document.createDocumentFragment();
+
+      diff.innerHTML(fragment, `
+        <p>Supports DocumentFragments</p>
+      `);
+
+      assert.equal(fragment.childNodes[0].nodeName.toLowerCase(), 'p');
+      assert.equal(fragment.childNodes[0].childNodes[0].nodeValue, 'Supports DocumentFragments');
+
+      diff.release(fragment);
+    });
+
+    it('can diff a fragment into an element', function() {
+      var fragment = document.createDocumentFragment();
+
+      diff.innerHTML(fragment, `
+        <h1>It works</h1>
+      `);
+
+      diff.element(this.fixture, fragment, { inner: true });
+
+      assert.equal(this.fixture.childNodes[0].nodeName.toLowerCase(), 'h1');
+      assert.equal(this.fixture.childNodes[0].childNodes[0].nodeValue, 'It works');
+
+      diff.release(fragment);
+    });
+  });
+
   describe('Custom elements', function() {
     it('supports the use of custom elements', function() {
       diff.innerHTML(this.fixture, '<custom-element></custom-element>');

--- a/test/unit/node.js
+++ b/test/unit/node.js
@@ -13,7 +13,6 @@ describe('Unit: Node', function() {
       var node = makeNode(document.createElement('div'));
 
       assert.equal(node.nodeName, 'div');
-      assert.equal(node.nodeType, 1);
       assert.equal(node.childNodes.length, 0);
       assert.equal(node.attributes.length, 0);
     });
@@ -22,7 +21,6 @@ describe('Unit: Node', function() {
       var node = makeNode(document.createTextNode('test'));
 
       assert.equal(node.nodeName, '#text');
-      assert.equal(node.nodeType, 3);
       assert.equal(node.nodeValue, 'test');
       assert.equal(node.childNodes.length, 0);
       assert.equal(node.attributes.length, 0);

--- a/test/unit/util/parser.js
+++ b/test/unit/util/parser.js
@@ -59,4 +59,12 @@ describe('Unit: Parser', function() {
     assert.equal(node.childNodes[1].childNodes.length, 1);
     assert.equal(node.childNodes[1].childNodes[0].nodeName, 'p');
   });
+
+  it('cannot support brackets in attribute values', function() {
+    var node = parser.parseHTML(`<a data-text="<li class='test'></li>"></a>`);
+
+    assert.equal(node.nodeName, 'a');
+    assert.equal(node.attributes[0].name, 'data-text');
+    assert.equal(node.attributes[0].value,  '\"<li');
+  });
 });


### PR DESCRIPTION
- Better support for DocumentFragments and ShadowDOM (tests needed)
- Better support for type extensions (is attribute) (more tests needed)
- Added in a test that shows we cannot support (yet) unescaped HTML inside attribute values
- Added back in code coverage filtering so that tests can run in the browser successfully
- Made changes to ensure object shapes don't change.