### PR TITLE
Fixes bugs with tagged template helper and escape

### DIFF
--- a/lib/html.js
+++ b/lib/html.js
@@ -4,6 +4,16 @@ import { parse } from './util/parser';
 const isPropEx = /(=|'|")/;
 
 /**
+ * Tiny HTML escaping function.
+ *
+ * @param str unescaped
+ * @return {String} escaped
+ */
+function encode(str) {
+  return str.replace(/["&'<>`]/g, match => `&#${match.charCodeAt(0)};`);
+}
+
+/**
  * Parses a tagged template literal into a diffHTML Virtual DOM representation.
  *
  * @param strings
@@ -12,6 +22,11 @@ const isPropEx = /(=|'|")/;
  * @return
  */
 export function html(strings, ...values) {
+  // Automatically coerce a string literal to array.
+  if (typeof strings === 'string') {
+    strings = [strings];
+  }
+
   // Do not attempt to parse empty strings.
   if (!strings[0].length && !values.length) {
     return null;
@@ -38,6 +53,10 @@ export function html(strings, ...values) {
       let lastSegment = string.split(' ').pop();
       let lastCharacter = lastSegment.trim().slice(-1);
       let isProp = Boolean(lastCharacter.match(isPropEx));
+
+      if (typeof value === 'string') {
+        value = encode(value);
+      }
 
       if (isProp) {
         supplemental.props.push(value);

--- a/lib/util/parser.js
+++ b/lib/util/parser.js
@@ -24,6 +24,8 @@ const kSelfClosingElements = {
   hr: true,
 };
 
+const TOKEN = '__DIFFHTML__';
+
 var kElementsClosedByOpening = {
   li: {
     li: true
@@ -89,6 +91,57 @@ var escapeMap = {
 };
 
 /**
+ * Interpolate dynamic supplemental values from the tagged template into the
+ * tree.
+ *
+ * @param currentParent
+ * @param string
+ * @param supplemental
+ */
+function interpolateDynamicBits(currentParent, string, supplemental) {
+  if (string && string.indexOf(TOKEN) > -1) {
+    const toAdd = [];
+
+    // Break up the incoming string into dynamic parts that are then pushed
+    // into a new set of child nodes.
+    string.split(TOKEN).forEach((value, index) => {
+      if (index === 0) {
+        // We trim here to allow for newlines before and after markup starts.
+        if (value && value.trim()) {
+          toAdd.push(TextNode(value));
+        }
+
+        // The first item does not mean there was dynamic content.
+        return;
+      }
+
+      // If we are in the second iteration, this
+      const dynamicBit = supplemental.children.shift();
+
+      if (typeof dynamicBit === 'string') {
+        toAdd.push(TextNode(dynamicBit));
+      }
+      else if (Array.isArray(dynamicBit)) {
+        toAdd.push.apply(toAdd, dynamicBit);
+      }
+      else {
+        toAdd.push(dynamicBit);
+      }
+
+      // This is a useful Text Node.
+      if (value && value.trim()) {
+        toAdd.push(TextNode(value));
+      }
+    });
+
+    currentParent.childNodes.push.apply(currentParent.childNodes, toAdd);
+  }
+  else if (string && string.length) {
+    currentParent.childNodes.push(TextNode(string));
+  }
+}
+
+/**
  * TextNode to contain a text element in DOM tree.
  * @param {string} value [description]
  */
@@ -133,7 +186,7 @@ function HTMLElement(name, keyAttrs, rawAttrs, supplemental) {
       attr.name = match[1];
       attr.value = match[6] || match[5] || match[4] || match[1];
 
-      if (attr.value === '__DIFFHTML__') {
+      if (attr.value === TOKEN) {
         attr.value = supplemental.props.shift();
       }
 
@@ -169,7 +222,7 @@ export function parse(data, supplemental) {
   // If there are no HTML elements, treat the passed in data as a single
   // text node.
   if (data.indexOf('<') === -1 && data) {
-    currentParent.childNodes.push(TextNode(data));
+    interpolateDynamicBits(currentParent, data, supplemental);
     return root;
   }
 
@@ -181,17 +234,17 @@ export function parse(data, supplemental) {
           lastTextPos, kMarkupPattern.lastIndex - match[0].length
         );
 
-        if (text && text.trim && text.trim() === '__DIFFHTML__') {
-          let value = supplemental.children.shift();
-          let childrenToAdd = [].concat(value);
+        interpolateDynamicBits(currentParent, text, supplemental);
+      }
+    }
 
-          currentParent.childNodes.push.apply(
-            currentParent.childNodes, childrenToAdd
-          );
-        }
-        else {
-          currentParent.childNodes.push(TextNode(text));
-        }
+    let matchOffset = kMarkupPattern.lastIndex - match[0].length;
+
+    if (lastTextPos === -1 && matchOffset > 0) {
+      let string = data.slice(0, matchOffset);
+
+      if (string && string.trim()) {
+        root.childNodes.push(TextNode(string));
       }
     }
 
@@ -249,7 +302,6 @@ export function parse(data, supplemental) {
 
           currentParent.childNodes.push(TextNode(newText));
         }
-
       }
     }
     if (match[1] || match[4] || kSelfClosingElements[match[2]]) {

--- a/test/integration/tagged-template.js
+++ b/test/integration/tagged-template.js
@@ -192,4 +192,14 @@ describe('Integration: Tagged template', function() {
       assert.ok(this.fixture.querySelector('footer'));
     });
   });
+
+  it('can support multiple interpolated values', function() {
+    diff.innerHTML(this.fixture, html`${html('foo')}${html('bar<baz></baz>')}`);
+    assert.equal(this.fixture.innerHTML, 'foobar<baz></baz>');
+  });
+
+  it('escapes incoming string values', function() {
+    diff.innerHTML(this.fixture, html`${'<baz>'}`);
+    assert.equal(this.fixture.innerHTML, '&lt;baz&gt;');
+  });
 });

--- a/test/unit/util/parser.js
+++ b/test/unit/util/parser.js
@@ -67,4 +67,13 @@ describe('Unit: Parser', function() {
     assert.equal(node.attributes[0].name, 'data-text');
     assert.equal(node.attributes[0].value,  '\"<li');
   });
+
+  it('supports parsing text before element', function() {
+    var nodes = parser.parse(`Hello <div></div>`).childNodes;
+
+    assert.equal(nodes.length, 2);
+    assert.equal(nodes[0].nodeName, '#text');
+    assert.equal(nodes[0].nodeValue, 'Hello ');
+    assert.equal(nodes[1].nodeName, 'div');
+  });
 });


### PR DESCRIPTION
The tagged template helper will now escape any interpolated text values.
This is a safer approach to directly injecting markup. If you wish to
embed raw markup you can use the `html` method directly like so:

``` js
function render() {
  let escaped = '<script>window.alert('xss')</script>';
  let unescaped = '<center>of attention</center>';

  outerHTML(document.body, html`<body>
    <p>Escaped: ${escaped}</p>
    <p>Unescaped: ${html(unescaped)}</p>
  </body>`);
}

render();
```

This patch also addresses two bugs with the parser. Text preceding the
first defined element would be discarded. Another bug was with two
dynamic interpolated values being right next to eachother not
transforming properly.