### PR TITLE
Refactor transaction completion + Babel polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,15 +62,10 @@ diffHTML is authored using many modern browser features, such as
 which are not available in [all
 browsers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set#Browser_compatibility).
 
-If you wish to use diffHTML in older browsers, make sure you have polyfills for
-at least:
+If you wish to use diffHTML in older browsers, make sure you have the Babel
+polyfill loaded first:
 
-- [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
-- [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set)
-- [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map)
-
-You can find polyfills for these globals in the core-js project:
-https://github.com/zloirock/core-js
+https://babeljs.io/docs/usage/polyfill/
 
 ##### Module format locations
 

--- a/dist/diffhtml-runtime.js
+++ b/dist/diffhtml-runtime.js
@@ -244,7 +244,107 @@ function enableProllyfill() {
   });
 }
 
-},{"./node/release":4,"./node/transaction":5,"./tree/helpers":6,"./util/tagged-template":16,"./util/transitions":17}],2:[function(_dereq_,module,exports){
+},{"./node/release":5,"./node/transaction":6,"./tree/helpers":7,"./util/tagged-template":16,"./util/transitions":17}],2:[function(_dereq_,module,exports){
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = getFinalizeCallback;
+
+var _transaction = _dereq_('../node/transaction');
+
+var _transaction2 = _interopRequireDefault(_transaction);
+
+var _cache = _dereq_('../util/cache');
+
+var _memory = _dereq_('../util/memory');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/**
+ * Pulls the next render object (containing the respective arguments to
+ * patchNode) and invokes the next transaction.
+ *
+ * @param state
+ */
+var renderNext = function renderNext(state) {
+  var nextRender = state.nextRender;
+  state.nextRender = undefined;
+
+  (0, _transaction2.default)(nextRender.node, nextRender.newHTML, nextRender.options);
+};
+
+/**
+ * Returns a callback that finalizes the transaction, setting the isRendering
+ * flag to false. This allows us to pick off and invoke the next available
+ * transaction to render. This code recyles the unprotected allocated pool
+ * objects and triggers a `renderComplete` event.
+ *
+ * @param {Object} node - A DOM Node that has just had patches applied
+ * @param {Object} state - The current state object associated with the Node
+ * @return {Function} - Closure that when called completes the transaction
+ */
+function getFinalizeCallback(node, state) {
+  /**
+   * When the render completes, clean up memory, and schedule the next render
+   * if necessary.
+   */
+  return function finalizeTransaction() {
+    var isInner = state.options.inner;
+
+    state.previousMarkup = isInner ? node.innerHTML : node.outerHTML;
+    state.previousText = node.textContent;
+
+    state.isRendering = false;
+
+    // This is designed to handle use cases where renders are being hammered
+    // or when transitions are used with Promises. If this element has a next
+    // render state, trigger it first as priority.
+    if (state.nextRender) {
+      renderNext(state);
+    }
+    // Otherwise dig into the other states and pick off the first one
+    // available.
+    else {
+        var _iteratorNormalCompletion = true;
+        var _didIteratorError = false;
+        var _iteratorError = undefined;
+
+        try {
+          for (var _iterator = _cache.StateCache.entries()[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+            var _state = _step.value;
+
+            if (_state.nextRender) {
+              renderNext(_state);
+              break;
+            }
+          }
+        } catch (err) {
+          _didIteratorError = true;
+          _iteratorError = err;
+        } finally {
+          try {
+            if (!_iteratorNormalCompletion && _iterator.return) {
+              _iterator.return();
+            }
+          } finally {
+            if (_didIteratorError) {
+              throw _iteratorError;
+            }
+          }
+        }
+      }
+
+    // Clean out all the existing allocations.
+    (0, _memory.cleanMemory)();
+
+    // Dispatch an event on the node once rendering has completed.
+    node.dispatchEvent(new CustomEvent('renderComplete'));
+  };
+}
+
+},{"../node/transaction":6,"../util/cache":10,"../util/memory":13}],3:[function(_dereq_,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -346,7 +446,7 @@ function make(vTree) {
   return node;
 }
 
-},{"../util/cache":9,"../util/svg":15}],3:[function(_dereq_,module,exports){
+},{"../util/cache":10,"../util/svg":15}],4:[function(_dereq_,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -771,7 +871,7 @@ function patchNode(node, patches) {
   return promises.filter(Boolean);
 }
 
-},{"../tree/sync":8,"../util/cache":9,"../util/entities":10,"../util/memory":12,"../util/parser":18,"../util/transitions":17,"./make":2}],4:[function(_dereq_,module,exports){
+},{"../tree/sync":9,"../util/cache":10,"../util/entities":11,"../util/memory":13,"../util/parser":18,"../util/transitions":17,"./make":3}],5:[function(_dereq_,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -804,7 +904,7 @@ function releaseNode(node) {
   (0, _memory.cleanMemory)();
 }
 
-},{"../util/cache":9,"../util/memory":12}],5:[function(_dereq_,module,exports){
+},{"../util/cache":10,"../util/memory":13}],6:[function(_dereq_,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -815,6 +915,10 @@ exports.default = createTransaction;
 var _patch = _dereq_('./patch');
 
 var _patch2 = _interopRequireDefault(_patch);
+
+var _finalize = _dereq_('./finalize');
+
+var _finalize2 = _interopRequireDefault(_finalize);
 
 var _make = _dereq_('../tree/make');
 
@@ -831,8 +935,6 @@ var _memory = _dereq_('../util/memory');
 var _parser = _dereq_('../util/parser');
 
 var _pools = _dereq_('../util/pools');
-
-var _render = _dereq_('../util/render');
 
 var _cache = _dereq_('../util/cache');
 
@@ -982,22 +1084,27 @@ function createTransaction(node, newHTML, options) {
 
   // Synchronize the tree.
   var patches = (0, _sync2.default)(state.oldTree, newTree);
+
+  // Apply the set of patches to the Node.
   var promises = (0, _patch2.default)(node, patches);
-  var invokeRender = (0, _render.completeRender)(node, state);
+
+  // Clean up and finalize this transaction. If there is another transaction,
+  // get a callback to run once this completes to run it.
+  var finalizeTransaction = (0, _finalize2.default)(node, state);
 
   // Operate synchronously unless opted into a Promise-chain. Doesn't matter if
   // they are actually Promises or not, since they will all resolve eventually
   // with `Promise.all`.
   if (promises.length) {
-    Promise.all(promises).then(invokeRender, function (ex) {
+    Promise.all(promises).then(finalizeTransaction, function (ex) {
       return console.log(ex);
     });
   } else {
-    invokeRender();
+    finalizeTransaction();
   }
 }
 
-},{"../tree/helpers":6,"../tree/make":7,"../tree/sync":8,"../util/cache":9,"../util/memory":12,"../util/parser":18,"../util/pools":13,"../util/render":14,"./patch":3}],6:[function(_dereq_,module,exports){
+},{"../tree/helpers":7,"../tree/make":8,"../tree/sync":9,"../util/cache":10,"../util/memory":13,"../util/parser":18,"../util/pools":14,"./finalize":2,"./patch":4}],7:[function(_dereq_,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -1109,7 +1216,7 @@ function createAttribute(name, value) {
   return entry;
 }
 
-},{"../tree/make":7,"../util/escape":11,"../util/pools":13}],7:[function(_dereq_,module,exports){
+},{"../tree/make":8,"../util/escape":12,"../util/pools":14}],8:[function(_dereq_,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -1192,7 +1299,7 @@ function makeNode(node) {
   return vTree;
 }
 
-},{"../util/cache":9,"../util/pools":13,"./helpers":6}],8:[function(_dereq_,module,exports){
+},{"../util/cache":10,"../util/pools":14,"./helpers":7}],9:[function(_dereq_,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -1557,7 +1664,7 @@ function sync(oldTree, newTree, patches) {
   return patches;
 }
 
-},{"../util/pools":13}],9:[function(_dereq_,module,exports){
+},{"../util/pools":14}],10:[function(_dereq_,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -1569,7 +1676,7 @@ var StateCache = exports.StateCache = new Map();
 // Associates Virtual Tree Elements with DOM Nodes.
 var NodeCache = exports.NodeCache = new Map();
 
-},{}],10:[function(_dereq_,module,exports){
+},{}],11:[function(_dereq_,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -1595,7 +1702,7 @@ function decodeEntities(string) {
   return element.textContent;
 }
 
-},{}],11:[function(_dereq_,module,exports){
+},{}],12:[function(_dereq_,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -1615,7 +1722,7 @@ function escape(unescaped) {
   });
 }
 
-},{}],12:[function(_dereq_,module,exports){
+},{}],13:[function(_dereq_,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -1708,7 +1815,7 @@ function cleanMemory() {
   attributeCache.allocated.clear();
 }
 
-},{"../util/pools":13,"./cache":9}],13:[function(_dereq_,module,exports){
+},{"../util/pools":14,"./cache":10}],14:[function(_dereq_,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -1790,83 +1897,7 @@ function initializePools(COUNT) {
 // Create ${COUNT} items of each type.
 initializePools(count);
 
-},{}],14:[function(_dereq_,module,exports){
-'use strict';
-
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports.completeRender = completeRender;
-
-var _transaction = _dereq_('../node/transaction');
-
-var _transaction2 = _interopRequireDefault(_transaction);
-
-var _cache = _dereq_('../util/cache');
-
-var _memory = _dereq_('../util/memory');
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-/**
- * Pulls the next render buffer object (containing the respective arguments to
- * patchNode) and invokes the next render transaction.
- *
- * @param state
- */
-var renderNext = function renderNext(state) {
-  var nextRender = state.nextRender;
-  state.nextRender = undefined;
-
-  (0, _transaction2.default)(nextRender.node, nextRender.newHTML, nextRender.options);
-};
-
-/**
- * When the render completes, clean up memory, and schedule the next render if
- * necessary.
- *
- * @param node
- * @param state
- * @return {Function} - Closure that when called completes rendering
- */
-function completeRender(node, state) {
-  return function invokeRender() {
-    var isInner = state.options.inner;
-
-    state.previousMarkup = isInner ? node.innerHTML : node.outerHTML;
-    state.previousText = node.textContent;
-
-    state.isRendering = false;
-
-    // Boolean to stop operations in the StateCache loop below.
-    var stopLooping = false;
-
-    // This is designed to handle use cases where renders are being hammered
-    // or when transitions are used with Promises. If this element has a next
-    // render state, trigger it first as priority.
-    if (state.nextRender) {
-      renderNext(state);
-    }
-    // Otherwise dig into the other states and pick off the first one
-    // available.
-    else {
-        _cache.StateCache.forEach(function (state) {
-          if (!stopLooping && state.nextRender) {
-            renderNext(state);
-            stopLooping = true;
-          }
-        });
-      }
-
-    // Clean out all the existing allocations.
-    (0, _memory.cleanMemory)();
-
-    // Dispatch an event on the node once rendering has completed.
-    node.dispatchEvent(new CustomEvent('renderComplete'));
-  };
-}
-
-},{"../node/transaction":5,"../util/cache":9,"../util/memory":12}],15:[function(_dereq_,module,exports){
+},{}],15:[function(_dereq_,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -1987,7 +2018,7 @@ function html(strings) {
   return childNodes.length > 1 ? childNodes : childNodes[0];
 }
 
-},{"./escape":11,"./parser":18}],17:[function(_dereq_,module,exports){
+},{"./escape":12,"./parser":18}],17:[function(_dereq_,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -7,8 +7,7 @@ module.exports = function(config) {
     frameworks: ['browserify', 'mocha'],
 
     files: [
-      'node_modules/promise-polyfill/promise.js',
-      'node_modules/es6-collections/es6-collections.js',
+      'node_modules/babel-polyfill/dist/polyfill.js',
       'lib/**/*.js',
       'test/assert.js',
 

--- a/lib/node/finalize.js
+++ b/lib/node/finalize.js
@@ -3,8 +3,8 @@ import { StateCache } from '../util/cache';
 import { cleanMemory } from '../util/memory';
 
 /**
- * Pulls the next render buffer object (containing the respective arguments to
- * patchNode) and invokes the next render transaction.
+ * Pulls the next render object (containing the respective arguments to
+ * patchNode) and invokes the next transaction.
  *
  * @param state
  */
@@ -16,24 +16,27 @@ const renderNext = (state) => {
 };
 
 /**
- * When the render completes, clean up memory, and schedule the next render if
- * necessary.
+ * Returns a callback that finalizes the transaction, setting the isRendering
+ * flag to false. This allows us to pick off and invoke the next available
+ * transaction to render. This code recyles the unprotected allocated pool
+ * objects and triggers a `renderComplete` event.
  *
- * @param node
- * @param state
- * @return {Function} - Closure that when called completes rendering
+ * @param {Object} node - A DOM Node that has just had patches applied
+ * @param {Object} state - The current state object associated with the Node
+ * @return {Function} - Closure that when called completes the transaction
  */
-export function completeRender(node, state) {
-  return function invokeRender() {
+export default function getFinalizeCallback(node, state) {
+  /**
+   * When the render completes, clean up memory, and schedule the next render
+   * if necessary.
+   */
+  return function finalizeTransaction() {
     const isInner = state.options.inner;
 
     state.previousMarkup = isInner ? node.innerHTML : node.outerHTML;
     state.previousText = node.textContent;
 
     state.isRendering = false;
-
-    // Boolean to stop operations in the StateCache loop below.
-    var stopLooping = false;
 
     // This is designed to handle use cases where renders are being hammered
     // or when transitions are used with Promises. If this element has a next
@@ -44,12 +47,12 @@ export function completeRender(node, state) {
     // Otherwise dig into the other states and pick off the first one
     // available.
     else {
-      StateCache.forEach(state => {
-        if (!stopLooping && state.nextRender) {
+      for (let state of StateCache.entries()) {
+        if (state.nextRender) {
           renderNext(state);
-          stopLooping = true;
+          break;
         }
-      });
+      }
     }
 
     // Clean out all the existing allocations.

--- a/lib/node/transaction.js
+++ b/lib/node/transaction.js
@@ -1,11 +1,11 @@
 import patchNode from './patch';
+import getFinalizeCallback from './finalize';
 import makeTree from '../tree/make';
 import syncTree from '../tree/sync';
 import { createElement } from '../tree/helpers';
 import { protectElement, unprotectElement } from '../util/memory';
 import { parse } from '../util/parser';
 import { pools } from '../util/pools';
-import { completeRender } from '../util/render';
 import { StateCache } from '../util/cache';
 
 /**
@@ -150,16 +150,21 @@ export default function createTransaction(node, newHTML, options) {
 
   // Synchronize the tree.
   const patches = syncTree(state.oldTree, newTree);
+
+  // Apply the set of patches to the Node.
   const promises = patchNode(node, patches);
-  const invokeRender = completeRender(node, state);
+
+  // Clean up and finalize this transaction. If there is another transaction,
+  // get a callback to run once this completes to run it.
+  const finalizeTransaction = getFinalizeCallback(node, state);
 
   // Operate synchronously unless opted into a Promise-chain. Doesn't matter if
   // they are actually Promises or not, since they will all resolve eventually
   // with `Promise.all`.
   if (promises.length) {
-    Promise.all(promises).then(invokeRender, ex => console.log(ex));
+    Promise.all(promises).then(finalizeTransaction, ex => console.log(ex));
   }
   else {
-    invokeRender();
+    finalizeTransaction();
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,15 +17,15 @@
     "test": "npm run jshint && npm run karma -- --single-run"
   },
   "devDependencies": {
-    "babel-cli": "^6.9.0",
+    "babel-cli": "^6.10.1",
     "babel-core": "^6.9.1",
+    "babel-polyfill": "^6.9.1",
     "babel-preset-es2015": "^6.9.0",
     "babelify": "^7.3.0",
     "browserify": "^13.0.1",
     "browserify-istanbul": "^2.0.0",
     "coveralls": "^2.11.9",
     "derequire": "^2.0.3",
-    "es6-collections": "^0.5.6",
     "isparta": "^4.0.0",
     "istanbul": "^0.4.3",
     "jshint": "^2.9.2",
@@ -36,7 +36,6 @@
     "karma-phantomjs-launcher": "^1.0.0",
     "mocha": "^2.5.3",
     "phantomjs-prebuilt": "^2.1.7",
-    "promise-polyfill": "^5.2.1",
     "watchify": "^3.7.0"
   }
 }


### PR DESCRIPTION
This adds in the Babel polyfill and removes all the others. I've added a
note to the README for including it in projects that need legacy
support.

I've also changed the util/render.js to be finalize.js under the node/
directory. The function name got updated to getFinalizeCallback which
more accurately summarizes what it does than completeRender.