### PR TITLE
Warns on invalid markup terminators

### DIFF
--- a/dist/diffhtml-runtime.js
+++ b/dist/diffhtml-runtime.js
@@ -1040,7 +1040,8 @@ var setBufferState = function setBufferState(state, nextRender) {
 var getTreeFromNewHTML = function getTreeFromNewHTML(newHTML, options, callback) {
   // This is HTML Markup, so we need to parse it.
   if (typeof newHTML === 'string') {
-    var childNodes = (0, _parser.parse)(newHTML).childNodes;
+    var silenceWarnings = options.silenceWarnings;
+    var childNodes = (0, _parser.parse)(newHTML, null, { silenceWarnings: silenceWarnings }).childNodes;
 
     // If we are dealing with innerHTML, use all the Nodes. If we're dealing
     // with outerHTML, we can only support diffing against a single element,
@@ -1120,6 +1121,8 @@ function createTransaction(node, newHTML, options) {
       state.newHTML = newHTML;
     }
 
+  // We rebuild the tree whenever the DOM Node changes, including the first
+  // time we patch a DOM Node.
   var rebuildTree = function rebuildTree() {
     var oldTree = state.oldTree;
 

--- a/lib/node/transaction.js
+++ b/lib/node/transaction.js
@@ -40,7 +40,8 @@ const setBufferState = (state, nextRender) => {
 const getTreeFromNewHTML = (newHTML, options, callback) => {
   // This is HTML Markup, so we need to parse it.
   if (typeof newHTML === 'string') {
-    const childNodes = parse(newHTML).childNodes;
+    const silenceWarnings = options.silenceWarnings;
+    const childNodes = parse(newHTML, null, { silenceWarnings }).childNodes;
 
     // If we are dealing with innerHTML, use all the Nodes. If we're dealing
     // with outerHTML, we can only support diffing against a single element,

--- a/lib/util/parser.js
+++ b/lib/util/parser.js
@@ -12,6 +12,7 @@ const doctypeEx = /<!.*>/ig;
 const attrEx = /\b([_a-z][_a-z0-9\-]*)\s*(=\s*("([^"]+)"|'([^']+)'|(\S+)))?/ig;
 const tagEx =
   /<!--[^]*?(?=-->)-->|<(\/?)([a-z\-][a-z0-9\-]*)\s*([^>]*?)(\/?)>/ig;
+const spaceEx = /[^ ]/;
 
 // We use this Set in the node/patch module so marking it exported.
 export const blockText = new Set([
@@ -155,14 +156,15 @@ const HTMLElement = (nodeName, rawAttrs, supplemental) => {
 /**
  * Parses HTML and returns a root element
  *
- * @param  {string} data      html
- * @param  {array} supplemental      data
- * @return {HTMLElement}      root element
+ * @param {String} html - String of HTML markup to parse into a Virtual Tree
+ * @param {Object} supplemental - Dynamic interpolated data values
+ * @param {Object} options - Contains options like silencing warnings
+ * @return {Object} - Parsed Virtual Tree Element
  */
-export function parse(html, supplemental) {
+export function parse(html, supplemental, options = {}) {
   const root = HTMLElement('#document-fragment');
+  const stack = [root];
   var currentParent = root;
-  var stack = [root];
   var lastTextPos = -1;
 
   // If there are no HTML elements, treat the passed in html as a single
@@ -243,7 +245,28 @@ export function parse(html, supplemental) {
         }
       }
     }
+
     if (match[1] || match[4] || selfClosing.has(match[2])) {
+      if (match[2] !== currentParent.rawNodeName && options.strict) {
+        const nodeName = currentParent.rawNodeName;
+
+        // Find a subset of the markup passed in to validate.
+        const markup = html.slice(
+          tagEx.lastIndex - match[0].length
+        ).split('\n').slice(0, 3);
+
+        // Position the caret next to the first non-whitespace character.
+        const caret = Array(spaceEx.exec(markup[0]).index).join(' ') + '^';
+
+        // Craft the warning message and inject it into the markup.
+        markup.splice(1, 0, `${caret}
+Possibly invalid markup. Saw ${match[2]}, expected ${nodeName}...
+        `);
+
+        // Throw an error message if the markup isn't what we expected.
+        throw new Error(`${markup.join('\n')}`);
+      }
+
       // </ or /> or <br> etc.
       while (currentParent) {
         if (currentParent.rawNodeName == match[2]) {
@@ -253,10 +276,11 @@ export function parse(html, supplemental) {
           break;
         }
         else {
-          let tag = kElementsClosedByClosing[currentParent.rawNodeName];
+          const tag = kElementsClosedByClosing[currentParent.rawNodeName];
 
           // Trying to close current tag, and move on
           if (tag) {
+
             if (tag[match[2]]) {
               stack.pop();
               currentParent = stack[stack.length - 1];
@@ -273,7 +297,7 @@ export function parse(html, supplemental) {
   }
 
   // Find any last remaining text after the parsing completes over tags.
-  var remainingText = html.slice(lastTextPos === -1 ? 0 : lastTextPos).trim();
+  const remainingText = html.slice(lastTextPos === -1 ? 0 : lastTextPos).trim();
 
   // If the text exists and isn't just whitespace, push into a new TextNode.
   interpolateDynamicBits(currentParent, remainingText, supplemental);

--- a/test/unit/util/parser.js
+++ b/test/unit/util/parser.js
@@ -1,6 +1,7 @@
 import * as parser from '../../../lib/util/parser';
 import { cleanMemory } from '../../../lib/util/memory';
 import validateMemory from '../../util/validateMemory';
+import { innerHTML, release } from '../../../lib/index';
 
 describe('Unit: Parser', function() {
   afterEach(function() {
@@ -115,5 +116,43 @@ describe('Unit: Parser', function() {
     assert.equal(nodes[1].nodeName, 'div');
     assert.equal(nodes[1].childNodes[0].nodeName, '#text');
     assert.equal(nodes[1].childNodes[0].nodeValue, 'Hello world');
+  });
+
+  it('will throw on invalid markup, when in strict mode', function() {
+    assert.throws(e => {
+      parser.parse(`
+        <span></span><div><div></div>
+        <ul>
+          <li>test</p>
+        </ul>
+        <div></div>
+        <div></div>
+        <div></div>
+        <div></div>
+        <div></div>
+        <div></div>
+      `, null, { strict: true }).childNodes[0];
+
+      assert.equal(ex.message,
+        "</p>\n^\nPossibly invalid markup. Saw p, expected li...\n        \n      </ul>\n      <div></div>"
+      );
+    });
+  });
+
+  it('will not throw on invalid markup when strict mode is false', function() {
+    assert.doesNotThrow(() => {
+      parser.parse(`
+        <span></span><div><div></div>
+        <ul>
+          <li>test</p>
+        </ul>
+        <div></div>
+        <div></div>
+        <div></div>
+        <div></div>
+        <div></div>
+        <div></div>
+      `, null, { strict: false }).childNodes[0];
+    });
   });
 });


### PR DESCRIPTION
If you write invalid markup, diffHTML now warns and points you to where the markup is invalid. I opt'd out of throwing since our parser is flexible and that is a plus in some cases. The only thing that is missing is a way to opt-out/disable the warnings.