### PR TITLE
Fix bug with text content and dynamic values

### DIFF
--- a/dist/diffhtml.js
+++ b/dist/diffhtml.js
@@ -2009,7 +2009,7 @@ function parse(html, supplemental) {
       var string = html.slice(0, matchOffset);
 
       if (string && string.trim() && !doctypeEx.exec(string)) {
-        root.childNodes.push(TextNode(string));
+        interpolateDynamicBits(currentParent, string, supplemental);
       }
     }
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+
+  <title>Index</title>
+</head>
+<body>
+  <script src="dist/diffhtml.js"></script>
+  <script src="dist/diffhtml-logger.js"></script>
+  <script>
+    diff.use(logger);
+
+    diff.addTransitionState('attached', () => {
+      return new Promise(resolve => {
+        setTimeout(resolve, 2000);
+      });
+    });
+
+    diff.outerHTML(document.body, `
+      <body>
+        <div>
+        Hello world
+        </div>
+      </body>
+    `);
+  </script>
+</body>
+</html>

--- a/lib/util/parser.js
+++ b/lib/util/parser.js
@@ -191,7 +191,7 @@ export function parse(html, supplemental) {
       let string = html.slice(0, matchOffset);
 
       if (string && string.trim() && !doctypeEx.exec(string)) {
-        root.childNodes.push(TextNode(string));
+        interpolateDynamicBits(currentParent, string, supplemental);
       }
     }
 

--- a/test/integration/tagged-template.js
+++ b/test/integration/tagged-template.js
@@ -182,4 +182,19 @@ describe('Integration: Tagged template', function() {
     diff.innerHTML(this.fixture, html`${'<baz>'}`);
     assert.equal(this.fixture.innerHTML, '&lt;baz&gt;');
   });
+
+  it('properly injects values where a text node appears first', function() {
+    var tableElement = document.createElement('table');
+    var anotherTableElement = document.createElement('table');
+
+    diff.innerHTML(this.fixture, html`
+      Foo ${tableElement} <div class="something">${anotherTableElement}</div>
+    `);
+
+    var expected = `
+      Foo <table></table><div class="something"><table></table></div>
+    `;
+
+    assert.equal(this.fixture.innerHTML.trim(), expected.trim());
+  });
 });


### PR DESCRIPTION
If a Text Node appears before any HTML element brackets, we would create
a Text Node with the content, even if the interpolation TOKEN was
present.