### PR TITLE
Fixes to the tests to support various browsers

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,10 +1,65 @@
 var isparta = require('isparta');
 var istanbul = require('browserify-istanbul');
 
+const browsers = {
+  OSX: {
+    os: 'OS X',
+    os_version: 'El Capitan',
+  },
+
+  Windows: {
+    os: 'Windows',
+    os_version: '10',
+  },
+
+  iOS: {
+    os: 'iOS',
+    os_version: '9.1',
+  },
+
+  Android: {
+    os: 'android',
+    os_version: '5.0',
+  }
+};
+
+const createBrowser = (name, version, browser='OSX') => ({
+  [`BS_${name}_${browser}`]: {
+    base: 'BrowserStack',
+    browser: name.toLowerCase(),
+    browser_version: version,
+    os: browsers[browser].os,
+    os_version: browsers[browser].os_version,
+  },
+});
+
 module.exports = function(config) {
   config.set({
     basePath: '.',
     frameworks: ['browserify', 'mocha'],
+
+    browserStack: {
+      username: process.env.BROWSER_STACK_USERNAME,
+      accessKey: process.env.BROWSER_STACK_KEY,
+    },
+
+    customLaunchers: Object.assign.apply({}, [
+      // OS X Evergreen.
+      createBrowser('Firefox'),
+      createBrowser('Chrome'),
+      createBrowser('Safari'),
+
+      // Windows Evergreen.
+      createBrowser('IE', null, 'Windows'),
+      createBrowser('Edge', null, 'Windows'),
+
+      // Non-evergreen OS X.
+      createBrowser('Opera'),
+
+      // Non-evergreen Mobile browsers.
+      createBrowser('iPhone', '9.1', 'iOS'),
+      createBrowser('Nexus', '5', 'Android'),
+    ]),
 
     files: [
       'node_modules/babel-polyfill/dist/polyfill.js',
@@ -52,8 +107,22 @@ module.exports = function(config) {
       ].filter(Boolean)
     },
 
-    browsers: [
-      'PhantomJS'
-    ]
+    browsers: process.env.BROWSER_STACK ? [
+      // Evergreen desktop.
+      'BS_Firefox_OSX',
+      'BS_Chrome_OSX',
+      'BS_Safari_OSX',
+      'BS_Edge_Windows',
+
+      // Currently failing due to undocumented `renderComplete` method.
+      //'BS_IE_Windows',
+
+      // Non-evergreen desktop.
+      'BS_Opera_OSX',
+
+      // Non-evergreen mobile.
+      'BS_Nexus_Android',
+      'BS_iPhone_iOS',
+    ] : ['PhantomJS']
   });
 };

--- a/lib/node/transaction.js
+++ b/lib/node/transaction.js
@@ -114,6 +114,8 @@ export default function createTransaction(node, newHTML, options) {
     state.newHTML = newHTML;
   }
 
+  // We rebuild the tree whenever the DOM Node changes, including the first
+  // time we patch a DOM Node.
   const rebuildTree = () => {
     const oldTree = state.oldTree;
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "jshint": "^2.9.2",
     "karma": "^0.13.22",
     "karma-browserify": "^5.0.5",
+    "karma-browserstack-launcher": "^1.0.1",
     "karma-coverage": "^1.0.0",
     "karma-mocha": "^1.0.1",
     "karma-phantomjs-launcher": "^1.0.0",

--- a/test/integration/basics.js
+++ b/test/integration/basics.js
@@ -68,7 +68,7 @@ describe('Integration: Basics', function() {
 
   describe('Special features', function() {
     it('can modify the document\'s title', function() {
-      var doc = document.implementation.createHTMLDocument();
+      var doc = document.implementation.createHTMLDocument('');
 
       doc.open();
       doc.write('<html><head><title></title></head></html>');

--- a/test/integration/inner.js
+++ b/test/integration/inner.js
@@ -41,7 +41,7 @@ describe('Integration: innerHTML', function() {
   describe('Text', function() {
     it('can decode HTML entities', function() {
       diff.innerHTML(this.fixture, '<div>&lt;</div>');
-      assert.equal(this.fixture.innerText, '<');
+      assert.equal(this.fixture.firstChild.textContent, '<');
     });
 
     it('can be override existing content', function() {
@@ -79,7 +79,7 @@ describe('Integration: innerHTML', function() {
     it('supports HTML5 entities', function() {
       diff.innerHTML(this.fixture, '<div>&gla;</div>');
 
-      assert.equal(this.fixture.firstChild.innerText, '⪥');
+      assert.equal(this.fixture.firstChild.textContent, '⪥');
     });
   });
 

--- a/test/integration/outer.js
+++ b/test/integration/outer.js
@@ -26,9 +26,13 @@ describe('Integration: outerHTML', function() {
   });
 
   it('can replace the documentElement', function() {
-    var doc = document.implementation.createHTMLDocument();
+    var doc = document.implementation.createHTMLDocument('');
     doc.open();
     doc.write('<html><head><title>Test</title></head></html>');
+
+    // Ensure the title is actually set, seems like Firefox does not do this
+    // automatically with `document.write`.
+    doc.title = 'Test';
 
     var documentElement = doc.documentElement;
     var originalSource = documentElement.outerHTML;


### PR DESCRIPTION
Not all browsers behaved with the tests, so I've gone through with
Browserstack and fixed the files that were not valid. Such as creating
an HTML Document without a title (apparently it's a required argument in
some browsers).


Here's the current support chart:

<table>
  <thead>
    <tr>
      <th>IE (9/10/11)
      <th>Edge (13)
      <th>Firefox (47)
      <th>Chrome (51)
      <th>Safari (9.1)
      <th>Opera (38)
      <th>iOS iPhone Safari (9.3)
      <th>Android Chrome (50)
  <tbody>
    <tr>
      <td>✗
      <td>✓
      <td>✓
      <td>✓
      <td>✓
      <td>✓
      <td>✓
      <td>✓
</table>

I can't get IE 11 to work just yet. I have an undocumented internal
event named `renderComplete`. I may have mentioned it on the website,
but it's definitely going away in it's current form. I'll bring it back
as middleware if anyone needs it.

For instance:

``` javascript
// middleware code
const renderCompleteMiddleware = start => ({ node }) => patch => complete => {
  node.dispatchEvent(new CustomEvent('renderComplete'))
})

export default renderCompleteMiddleware

// how you would use it

diff.use(renderCompleteMiddleware)

document.body.addEventListener('renderComplete', ev => {
  console.log('Rendering complete on %o', document.body)
})

diff.innerHTML(document.body, `<div></div>`)
```