### PR TITLE
Fixes parser issue with pre code blocks

### DIFF
--- a/dist/diffhtml.js
+++ b/dist/diffhtml.js
@@ -1888,7 +1888,7 @@ var tagEx = /<!--[^]*?(?=-->)-->|<(\/?)([a-z\-][a-z0-9\-]*)\s*([^>]*?)(\/?)>/ig;
 var spaceEx = /[^ ]/;
 
 // We use this Set in the node/patch module so marking it exported.
-var blockText = exports.blockText = new Set(['script', 'noscript', 'style', 'pre', 'template']);
+var blockText = exports.blockText = new Set(['script', 'noscript', 'style', 'code', 'template']);
 
 var selfClosing = new Set(['meta', 'img', 'link', 'input', 'area', 'br', 'hr']);
 
@@ -2093,10 +2093,7 @@ function parse(html, supplemental) {
         }
 
         var newText = html.slice(match.index + match[0].length, index);
-
-        if (newText.trim()) {
-          currentParent.childNodes.push(TextNode((0, _escape2.default)(newText)));
-        }
+        interpolateDynamicBits(currentParent, newText.trim(), supplemental);
       }
     }
 

--- a/lib/util/parser.js
+++ b/lib/util/parser.js
@@ -19,7 +19,7 @@ export const blockText = new Set([
   'script',
   'noscript',
   'style',
-  'pre',
+  'code',
   'template',
 ]);
 
@@ -239,10 +239,7 @@ export function parse(html, supplemental, options = {}) {
         }
 
         let newText = html.slice(match.index + match[0].length, index);
-
-        if (newText.trim()) {
-          currentParent.childNodes.push(TextNode(escape(newText)));
-        }
+        interpolateDynamicBits(currentParent, newText.trim(), supplemental);
       }
     }
 

--- a/test/unit/util/parser.js
+++ b/test/unit/util/parser.js
@@ -155,4 +155,71 @@ describe('Unit: Parser', function() {
       `, null, { strict: false }).childNodes[0];
     });
   });
+
+  it('supports nested elements within <pre>', function() {
+    var nodes = parser.parse(`<pre><code></code></pre>`).childNodes;
+
+    assert.equal(nodes[0].nodeName, 'pre');
+    assert.equal(nodes[0].childNodes.length, 1);
+    assert.equal(nodes[0].childNodes[0].nodeName, 'code');
+  });
+
+  it('does not support nested elements within <script>', function() {
+    var nodes = parser.parse(`<script><pre></pre></script>`).childNodes;
+
+    assert.equal(nodes[0].nodeName, 'script');
+    assert.equal(nodes[0].childNodes.length, 1);
+    assert.equal(nodes[0].childNodes[0].nodeName, '#text');
+    assert.equal(nodes[0].childNodes[0].nodeValue, '<pre></pre>');
+  });
+
+  it('does not support nested elements within <noscript>', function() {
+    var nodes = parser.parse(`<noscript><pre></pre></noscript>`).childNodes;
+
+    assert.equal(nodes[0].nodeName, 'noscript');
+    assert.equal(nodes[0].childNodes.length, 1);
+    assert.equal(nodes[0].childNodes[0].nodeName, '#text');
+    assert.equal(nodes[0].childNodes[0].nodeValue, '<pre></pre>');
+  });
+
+  it('does not support nested elements within <style>', function() {
+    var nodes = parser.parse(`<style><pre></pre></style>`).childNodes;
+
+    assert.equal(nodes[0].nodeName, 'style');
+    assert.equal(nodes[0].childNodes.length, 1);
+    assert.equal(nodes[0].childNodes[0].nodeName, '#text');
+    assert.equal(nodes[0].childNodes[0].nodeValue, '<pre></pre>');
+  });
+
+  it('does not support nested elements within <code>', function() {
+    var nodes = parser.parse(`<code><pre></pre></code>`).childNodes;
+
+    assert.equal(nodes[0].nodeName, 'code');
+    assert.equal(nodes[0].childNodes.length, 1);
+    assert.equal(nodes[0].childNodes[0].nodeName, '#text');
+    assert.equal(nodes[0].childNodes[0].nodeValue, '<pre></pre>');
+  });
+
+  it('does not support nested elements within <template>', function() {
+    var nodes = parser.parse(`<template><pre></pre></template>`).childNodes;
+
+    assert.equal(nodes[0].nodeName, 'template');
+    assert.equal(nodes[0].childNodes.length, 1);
+    assert.equal(nodes[0].childNodes[0].nodeName, '#text');
+    assert.equal(nodes[0].childNodes[0].nodeValue, '<pre></pre>');
+  });
+
+  it('supports self closing elements', function() {
+    var nodes = parser.parse(`
+      <meta/>
+      <img/>
+      <link/>
+      <input/>
+      <area/>
+      <br/>
+      <hr/>
+    `.trim()).childNodes.filter(el => el.nodeType === 1);
+
+    assert.equal(nodes.length, 7);
+  });
 });


### PR DESCRIPTION
`<pre>` tags can easily nest elements like `<code>`, so I've updated the parser to not treat all `<pre>` contents as text. I have updated the `<code>` element to treat all contents as text though.

I've also updated the parser to interpolate dynamic values into these blocks.

Basically:

``` js
const someCoolVariable = "Hello world";
```

``` html
<pre>
  <code>
    ${someCoolVariable}
  </code>
</pre>
```

Was rendering out as:

``` html
<pre>
  &lt;code&gt;
    __DIFFHTML__
  &lt;/code&gt;
</pre>
```

This fixes it to produce the correct output:

``` html
<pre>
  <code>
    Hello world
  </code>
</pre>
```