### PR TITLE
detect trim instead of executing it

### DIFF
--- a/lib/util/parser.js
+++ b/lib/util/parser.js
@@ -192,7 +192,7 @@ export function parse(html, supplemental, options = {}) {
     if (lastTextPos === -1 && matchOffset > 0) {
       let string = html.slice(0, matchOffset);
 
-      if (string && string.trim() && !doctypeEx.exec(string)) {
+      if (string && string.trim && !doctypeEx.exec(string)) {
         interpolateDynamicBits(currentParent, string, supplemental);
       }
     }


### PR DESCRIPTION
/cc @tbranyen It looks like trim should not be executed for performance reasons.

However this might not be a correct fix.

What probably could have happened instead is that `typeof string === "string"` detection on the top of the `parse` function body, and to polyfill trim instead (this can probably be handled by Babel's polyfill).