### PR TITLE
Wrap try/catch in function so parent isn't deopt'd

### DIFF
--- a/packages/diffhtml/lib/node/patch.js
+++ b/packages/diffhtml/lib/node/patch.js
@@ -7,6 +7,7 @@ import {
   unprotectVTree,
   decodeEntities,
   escape,
+  tryCatcher
 } from '../util';
 
 const blockText = new Set(['script', 'noscript', 'style', 'code', 'template']);
@@ -50,9 +51,7 @@ export default function patchNode(patches) {
 
         // Allow the user to find the real value in the DOM Node as a
         // property.
-        try {
-          domNode[name] = value;
-        } catch (unhandledException) {}
+        tryCatcher(() => domNode[name] = value);
 
         // Set the actual attribute, this will ensure attributes like
         // `autofocus` aren't reset by the property call above.
@@ -78,9 +77,7 @@ export default function patchNode(patches) {
         domNode.setAttribute(name, '');
 
         // Since this is a property value it gets set directly on the node.
-        try {
-          domNode[name] = value;
-        } catch (unhandledException) {}
+        tryCatcher(() => domNode[name] = value);
       }
 
       if (newPromises.length) {

--- a/packages/diffhtml/lib/util/index.js
+++ b/packages/diffhtml/lib/util/index.js
@@ -6,3 +6,4 @@ export { default as escape } from './escape';
 export { default as makeMeasure } from './performance';
 export { default as Pool } from './pool';
 export { default as parse } from './parser';
+export { default as tryCatcher } from './try-catcher';

--- a/packages/diffhtml/lib/util/try-catcher.js
+++ b/packages/diffhtml/lib/util/try-catcher.js
@@ -1,0 +1,10 @@
+/**
+ * Swallows any exceptions from the provided callback.
+ *
+ * @param  {Function} callback
+ */
+export default function tryCatcher(callback) {
+    try {
+        callback();
+    } catch (unhandledException) {}
+}


### PR DESCRIPTION
try/catch blocks deoptimize a function in V8. Wrapping the try/catch in
a function ensures only the `tryCatcher` is deoptimized, rather than
the entire function.

I'm not a perf guy; I stole this from [most.js](https://github.com/cujojs/most/issues/137#issuecomment-101654416).