### PR TITLE
Lowercases all event names, normalizes to 'on*'

### DIFF
--- a/packages/diffhtml-middleware-inline-transitions/README.md
+++ b/packages/diffhtml-middleware-inline-transitions/README.md
@@ -11,6 +11,15 @@ Tiny module to support binding/unbinding declarative diffHTML transition hooks.
 npm install diffhtml-middleware-inline-transitions
 ```
 
+##### Use
+
+``` js
+import { use } from 'diffhtml';
+import inlineTransitions from 'diffhtml-middleware-inline-transitions';
+
+use(inlineTransitions());
+```
+
 ##### Example
 
 Apply to an element by passing the function to the associated state name:
@@ -41,4 +50,4 @@ Full events and args list:
 | `ondetached`         | `(eventTarget, domNode)`
 | `onreplaced`         | `(eventTarget, oldNode, newNode)`
 | `onattributechanged` | `(eventTarget, oldNode, attributeName, oldValue, newValue)`
-| `onTextChanged`      | `(eventTarget, oldNode, oldValue, newValue)`
+| `ontextchanged`      | `(eventTarget, oldNode, oldValue, newValue)`

--- a/packages/diffhtml-middleware-inline-transitions/test/basics.js
+++ b/packages/diffhtml-middleware-inline-transitions/test/basics.js
@@ -1,13 +1,11 @@
 const assert = require('assert');
-const diff = require('diffhtml');
+const { use, html, innerHTML } = require('diffhtml');
 const inlineTransitions = require('../index');
-
-const { innerHTML, html } = diff;
 
 describe('Basics', function() {
   beforeEach(() => {
     this.fixture = document.createElement('div');
-    this.unsubscribeInlineTransitions = inlineTransitions(diff);
+    this.unsubscribeInlineTransitions = use(inlineTransitions());
   });
 
   afterEach(() => {
@@ -20,7 +18,7 @@ describe('Basics', function() {
       done();
     };
 
-    innerHTML(this.fixture, html`<div attached=${attached}></div>`);
+    innerHTML(this.fixture, html`<div onattached=${attached}></div>`);
   });
 
   it('can stop listening for hooks', () => {
@@ -31,33 +29,33 @@ describe('Basics', function() {
       count++;
     };
 
-    innerHTML(this.fixture, html`<div attached=${attached}></div>`);
+    innerHTML(this.fixture, html`<div onattached=${attached}></div>`);
 
     this.unsubscribeInlineTransitions();
 
-    innerHTML(this.fixture, html`<div attached=${attached}>
+    innerHTML(this.fixture, html`<div onattached=${attached}>
       <div></div>
     </div>`);
 
     assert.equal(count, 1);
   });
 
-  it('will pass through types to a hook', () => {
+  it('will set literal values directly on the element', () => {
     const attached = true;
-    innerHTML(this.fixture, html`<div attached=${attached}></div>`);
-    assert.equal(this.fixture.firstChild.getAttribute('attached'), true);
+    innerHTML(this.fixture, html`<div onattached=${attached}></div>`);
+    assert.equal(this.fixture.firstChild.getAttribute('onattached'), 'true');
   });
 
   it('can halt on a promise', (done) => {
-    const detached = el => {
-      return new Promise(resolve => setTimeout(resolve, 0));
-    };
+    const ondetached = el => new Promise(resolve => setTimeout(resolve, 0));
 
-    innerHTML(this.fixture, html`<div detached=${detached}>
-      <p></p>
-    </div>`);
+    innerHTML(this.fixture, html`
+      <div ondetached=${ondetached}>
+        <p></p>
+      </div>
+    `);
 
-    innerHTML(this.fixture, html`<div detached=${detached}></div>`);
+    innerHTML(this.fixture, html`<div ondetached=${ondetached}></div>`);
 
     assert.ok(this.fixture.querySelector('p'));
 
@@ -68,12 +66,12 @@ describe('Basics', function() {
   });
 
   it('supports detached transitions on the root element', (done) => {
-    const detached = el => {
-      assert.equal(el.nodeName, 'p')
+    const ondetached = el => {
+      assert.equal(el.nodeName.toLowerCase(), 'p')
       done();
     };
 
-    innerHTML(this.fixture, html`<div><p detached=${detached}/></div>`);
-    innerHTML(this.fixture, html`<div></div>`);
+    innerHTML(this.fixture, html`<p ondetached=${ondetached}/>`);
+    innerHTML(this.fixture, html``);
   });
 });

--- a/packages/diffhtml-middleware-inline-transitions/test/regressions.js
+++ b/packages/diffhtml-middleware-inline-transitions/test/regressions.js
@@ -1,13 +1,11 @@
 const assert = require('assert');
-const diff = require('diffhtml');
+const { use, html, innerHTML } = require('diffhtml');
 const inlineTransitions = require('../index');
-
-const { innerHTML, html } = diff;
 
 describe('Regressions', function() {
   beforeEach(() => {
     this.fixture = document.createElement('div');
-    this.unsubscribeInlineTransitions = inlineTransitions(diff);
+    this.unsubscribeInlineTransitions = use(inlineTransitions());
   });
 
   afterEach(() => {
@@ -17,14 +15,16 @@ describe('Regressions', function() {
   it('does not error when non-Promises are returned', () => {
     var count = 0;
 
-    const attached = el => {
+    const onattached = el => {
       count++;
       return undefined;
     };
 
-    innerHTML(this.fixture, html`<div attached=${attached}>
-      <div></div>
-    </div>`);
+    innerHTML(this.fixture, html`
+      <div onattached=${onattached}>
+        <div></div>
+      </div>
+    `);
 
     assert.equal(count, 2);
   });


### PR DESCRIPTION
This commit updates the README to flatten all event names to lower case,
but does not require it. It updates the signature of the event lookup to
be: 'onattached' from 'attached', this indicates its more of an event
that is frequently called. Since none of these events currently
collide with browser events it shouldn't be an issue. Although if they
ever do, I'm sure this project may be long dead by then...