### PR TITLE
Bugfix/shared internals and middleware

### DIFF
--- a/packages/diffhtml-shared-internals/lib/create-node.js
+++ b/packages/diffhtml-shared-internals/lib/create-node.js
@@ -1,0 +1,1 @@
+export { default as createNode } from 'diffhtml/lib/node/create';

--- a/packages/diffhtml-shared-internals/lib/decode-entities.js
+++ b/packages/diffhtml-shared-internals/lib/decode-entities.js
@@ -1,1 +1,1 @@
-export * from 'diffhtml/lib/util/decode-entities';
+export { default as decodeEntities } from 'diffhtml/lib/util/decode-entities';

--- a/packages/diffhtml-shared-internals/lib/escape.js
+++ b/packages/diffhtml-shared-internals/lib/escape.js
@@ -1,1 +1,1 @@
-export * from 'diffhtml/lib/util/escape';
+export { default as escape } from 'diffhtml/lib/util/escape';

--- a/packages/diffhtml-shared-internals/lib/index.js
+++ b/packages/diffhtml-shared-internals/lib/index.js
@@ -1,4 +1,5 @@
 export * from './caches';
+export * from './create-node';
 export * from './decode-entities';
 export * from './escape';
 export * from './make-measure';

--- a/packages/diffhtml/lib/tree/sync.js
+++ b/packages/diffhtml/lib/tree/sync.js
@@ -63,7 +63,7 @@ Virtual Element: ${JSON.stringify(vTree, null, 2)}`
   // `newTree`. Pass along the `keysLookup` object so that middleware can make
   // smart decisions when dealing with keys.
   SyncTreeHookCache.forEach((fn, retVal) => {
-    if (retVal = fn(oldTree, newTree, null)) {
+    if ((retVal = fn(oldTree, newTree, null)) && retVal !== newTree) {
       newTree = retVal;
 
       // Find attributes.


### PR DESCRIPTION
We only need to resync the tree if it's a completely new instance. If userland returns the same instance, `syncTree` will be called recursively indefinitely.