### PR TITLE
Add module & jsnext:main

### DIFF
--- a/packages/diffhtml-components/package.json
+++ b/packages/diffhtml-components/package.json
@@ -2,6 +2,8 @@
   "name": "diffhtml-components",
   "version": "1.0.0-beta",
   "main": "dist/cjs/index",
+  "module": "dist/es/index",
+  "jsnext:main": "dist/es/index",
   "esnext:main": "dist/es/index",
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/packages/diffhtml-shared-internals/package.json
+++ b/packages/diffhtml-shared-internals/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.0-beta",
   "description": "Access the diffHTML core internals",
   "main": "dist/cjs/index",
+  "module": "dist/es/index",
+  "jsnext:main": "dist/es/index",
   "esnext:main": "dist/es/index",
   "author": "Tim Branyen (@tbranyen)",
   "repository": "https://github.com/tbranyen/diffhtml",

--- a/packages/diffhtml/package.json
+++ b/packages/diffhtml/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.0-beta",
   "description": "Build JavaScript components and apps using a Virtual DOM",
   "main": "dist/cjs/index",
+  "module": "dist/es/index",
+  "jsnext:main": "dist/es/index",
   "esnext:main": "dist/es/index",
   "author": "Tim Branyen (@tbranyen)",
   "repository": "https://github.com/tbranyen/diffhtml",


### PR DESCRIPTION
`module` is used by rollup; `jsnext:main` is what it used to use.