### PR TITLE
Reexport default exports from shared-internals

### DIFF
--- a/packages/diffhtml-components/test/component.js
+++ b/packages/diffhtml-components/test/component.js
@@ -1,6 +1,6 @@
 import { ok, equal, throws, doesNotThrow } from 'assert';
 import { innerHTML, html, use } from 'diffhtml';
-import process from 'diffhtml-shared-internals/lib/process';
+import { process } from 'diffhtml-shared-internals';
 import PropTypes from 'prop-types';
 import Component from '../lib/component';
 

--- a/packages/diffhtml-shared-internals/lib/make-measure.js
+++ b/packages/diffhtml-shared-internals/lib/make-measure.js
@@ -1,1 +1,1 @@
-export * from 'diffhtml/lib/util/make-measure';
+export { default as makeMeasure } from 'diffhtml/lib/util/make-measure';

--- a/packages/diffhtml-shared-internals/lib/parser.js
+++ b/packages/diffhtml-shared-internals/lib/parser.js
@@ -1,1 +1,1 @@
-export * from 'diffhtml/lib/util/parser';
+export { default as parse } from 'diffhtml/lib/util/parser';

--- a/packages/diffhtml-shared-internals/lib/pool.js
+++ b/packages/diffhtml-shared-internals/lib/pool.js
@@ -1,1 +1,1 @@
-export * from 'diffhtml/lib/util/pool';
+export { default as Pool } from 'diffhtml/lib/util/pool';

--- a/packages/diffhtml-shared-internals/lib/process.js
+++ b/packages/diffhtml-shared-internals/lib/process.js
@@ -1,1 +1,1 @@
-export { default } from 'diffhtml/lib/util/process';
+export { default as process } from 'diffhtml/lib/util/process';


### PR DESCRIPTION
Some of these are default exports, which aren't getting reexported
properly from the shared-internals module.