### PR TITLE
Updates to Component/Web Component

### DIFF
--- a/packages/diffhtml-components/lib/tasks/react-like-component.js
+++ b/packages/diffhtml-components/lib/tasks/react-like-component.js
@@ -134,16 +134,21 @@ reactLikeComponentTask.syncTreeHook = (oldTree, newTree) => {
       }
 
       if (renderTree.nodeType === 11) {
-        throw new Error('Top level render must return single Node');
+        newTree.childNodes = [...renderTree.childNodes];
+
+        if (instance) {
+          ComponentTreeCache.set(instance, oldTree);
+          InstanceCache.set(oldTree, instance);
+        }
       }
+      else {
+        // Build a new tree from the render, and use this as the current tree.
+        newTree.childNodes[i] = renderTree;
 
-      // Build a new tree from the render, and use this as the current tree.
-      newTree.childNodes[i] = renderTree;
-
-      // Cache this new current tree.
-      if (instance) {
-        ComponentTreeCache.set(instance, renderTree);
-        InstanceCache.set(renderTree, instance);
+        if (instance) {
+          ComponentTreeCache.set(instance, renderTree);
+          InstanceCache.set(renderTree, instance);
+        }
       }
 
       // Recursively update trees.

--- a/packages/diffhtml-components/lib/tasks/web-component.js
+++ b/packages/diffhtml-components/lib/tasks/web-component.js
@@ -55,6 +55,10 @@ webComponentTask.syncTreeHook = (oldTree, newTree) => {
   // implemented by a higher-level abstraction. The only method ever called is
   // `render`. It is up to a higher level abstraction on how to handle the
   // changes.
+  if (!newTree || !newTree.childNodes) {
+    return newTree;
+  }
+
   for (let i = 0; i < newTree.childNodes.length; i++) {
     const oldChild = oldTree && oldTree.childNodes && oldTree.childNodes[i];
     const newChild = newTree.childNodes[i];
@@ -66,6 +70,8 @@ webComponentTask.syncTreeHook = (oldTree, newTree) => {
       });
     }
   }
+
+  return newTree;
 };
 
 webComponentTask.createNodeHook = (vTree) => {

--- a/packages/diffhtml-components/lib/web-component.js
+++ b/packages/diffhtml-components/lib/web-component.js
@@ -1,4 +1,4 @@
-import { innerHTML, use } from 'diffhtml';
+import { createTree, innerHTML, use } from 'diffhtml';
 import PropTypes from 'prop-types';
 import upgradeSharedClass from './shared/upgrade-shared-class';
 import webComponentTask from './tasks/web-component';
@@ -13,10 +13,13 @@ const getObserved = ({ propTypes }) => propTypes ? keys(propTypes) : [];
 // Creates the `component.props` object.
 const createProps = domNode => {
   const observedAttributes = getObserved(domNode.constructor);
+  const initialProps = {
+    children: [].map.call(domNode.childNodes, createTree),
+  };
 
   return observedAttributes.reduce((props, attr) => assign(props, {
     [attr]: attr in domNode ? domNode[attr] : domNode.getAttribute(attr) || undefined,
-  }), {});
+  }), initialProps);
 };
 
 // Creates the `component.state` object.

--- a/packages/diffhtml-components/test/component.js
+++ b/packages/diffhtml-components/test/component.js
@@ -29,22 +29,7 @@ describe('React Like Component', function() {
     equal(domNode.outerHTML, '<div><div>Hello world</div></div>');
   });
 
-  it('cannot return multiple elements yet', () => {
-    class CustomComponent extends Component {
-      render() {
-        return html`
-          <div>Hello world</div>
-          <p>Test</p>
-        `;
-      }
-    }
-
-    const domNode = document.createElement('div');
-
-    throws(() => innerHTML(domNode, html`<${CustomComponent} />`));
-  });
-
-  it.skip('can return multiple elements', () => {
+  it('can return multiple elements', () => {
     class CustomComponent extends Component {
       render() {
         return html`
@@ -57,7 +42,7 @@ describe('React Like Component', function() {
     const domNode = document.createElement('div');
     innerHTML(domNode, html`<${CustomComponent} />`);
 
-    equal(domNode.outerHTML, '<div><div>Hello world</div><p>test</p></div>');
+    equal(domNode.outerHTML, '<div><div>Hello world</div>\n          <p>Test</p></div>');
   });
 
   describe('Lifecycle', () => {

--- a/packages/diffhtml-components/test/web-component.js
+++ b/packages/diffhtml-components/test/web-component.js
@@ -56,7 +56,7 @@ describe('Web Component', function() {
       equal(ctorMessage, 'Test');
     });
 
-    it.only('can pass children in properties to constructor', () => {
+    it('can pass children in properties to constructor', () => {
       let children = null;
 
       class CustomComponent extends WebComponent {

--- a/packages/diffhtml-components/test/web-component.js
+++ b/packages/diffhtml-components/test/web-component.js
@@ -1,4 +1,4 @@
-import { equal, throws, doesNotThrow } from 'assert';
+import { deepEqual, equal, throws, doesNotThrow } from 'assert';
 import { innerHTML, html, createTree, use } from 'diffhtml';
 import PropTypes from 'prop-types';
 import WebComponent from '../lib/web-component';
@@ -31,28 +31,60 @@ describe('Web Component', function() {
     equal(document.body.innerHTML, '<custom-component></custom-component>');
   });
 
-  it('can pass properties to constructor', () => {
-    let ctorMessage = null;
+  describe('Props', () => {
+    it('can pass properties to constructor', () => {
+      let ctorMessage = null;
 
-    class CustomComponent extends WebComponent {
-      render({ message }) {
-        return html`
-          <div>${message}</div>
-        `;
+      class CustomComponent extends WebComponent {
+        render({ message }) {
+          return html`
+            <div>${message}</div>
+          `;
+        }
+
+        constructor(props) {
+          super(props);
+
+          ctorMessage = props.message;
+        }
       }
 
-      constructor(props) {
-        super(props);
+      customElements.define('custom-component', CustomComponent);
 
-        ctorMessage = props.message;
+      innerHTML(document.body, html`<custom-component message="Test" />`);
+
+      equal(ctorMessage, 'Test');
+    });
+
+    it.only('can pass children in properties to constructor', () => {
+      let children = null;
+
+      class CustomComponent extends WebComponent {
+        render({ message }) {
+          return html`
+            <div>${message}</div>
+          `;
+        }
+
+        constructor(props) {
+          super(props);
+
+          children = props.children;
+        }
       }
-    }
 
-    customElements.define('custom-component', CustomComponent);
+      customElements.define('custom-component', CustomComponent);
 
-    innerHTML(document.body, html`<custom-component message="Test" />`);
+      innerHTML(document.body, html`<custom-component message="Test">
+        <span>Testing</span>
+      </custom-component>`);
 
-    equal(ctorMessage, 'Test');
+      deepEqual(children, [
+        createTree('#text', '\n        '),
+        createTree('span', null, 'Testing'),
+        createTree('#text', '\n      '),
+      ]);
+    });
   });
 
   describe('JSX Compatibility', () => {

--- a/packages/diffhtml/lib/node/create.js
+++ b/packages/diffhtml/lib/node/create.js
@@ -1,8 +1,8 @@
 import { NodeCache, MiddlewareCache } from '../util/caches';
-import { namespace } from '../util/svg';
 import process from '../util/process';
 
 const { CreateNodeHookCache } = MiddlewareCache;
+const namespace = 'http://www.w3.org/2000/svg';
 
 /**
  * Takes in a Virtual Tree Element (VTree) and creates a DOM Node from it.

--- a/packages/diffhtml/lib/tree/create.js
+++ b/packages/diffhtml/lib/tree/create.js
@@ -127,9 +127,22 @@ export default function createTree(input, attributes, childNodes, ...rest) {
   if (nodes && nodeArray.length) {
     for (let i = 0; i < nodeArray.length; i++) {
       const newNode = nodeArray[i];
+      const isArray = Array.isArray(newNode);
 
+      // Merge in arrays.
+      if (isArray) {
+        for (let i = 0; i < newNode.length; i++) {
+          entry.childNodes.push(newNode[i]);
+        }
+      }
+      // Merge in fragments.
+      else if (newNode.nodeType === 11 && typeof newNode.rawNodeName === 'string') {
+        for (let i = 0; i < newNode.childNodes.length; i++) {
+          entry.childNodes.push(newNode.childNodes[i]);
+        }
+      }
       // Assume objects are vTrees.
-      if (typeof newNode === 'object') {
+      else if (newNode && typeof newNode === 'object') {
         entry.childNodes.push(newNode);
       }
       // Cover generate cases where a user has indicated they do not want a

--- a/packages/diffhtml/lib/util/internals.js
+++ b/packages/diffhtml/lib/util/internals.js
@@ -5,18 +5,12 @@ import makeMeasure from './make-measure';
 import * as memory from './memory';
 import Pool from './pool';
 import process from './process';
-import * as svg from './svg';
 
-const root = typeof global !== 'undefined' ? global : window;
-
-const internals = root[Symbol.for('diff.shared-internals')] = Object.assign({
+export default Object.assign({
   decodeEntities,
   escape,
   makeMeasure,
   memory,
   Pool,
   process,
-  svg,
 }, caches);
-
-export default internals;

--- a/packages/diffhtml/lib/util/svg.js
+++ b/packages/diffhtml/lib/util/svg.js
@@ -1,2 +1,0 @@
-// Namespace.
-export const namespace = 'http://www.w3.org/2000/svg';

--- a/packages/diffhtml/rollup.runtime.config.js
+++ b/packages/diffhtml/rollup.runtime.config.js
@@ -29,18 +29,6 @@ export const plugins = [
   hypothetical({
     allowRealFiles: true,
     files: {
-      './lib/html.js': `
-        import createTree from './tree/create';
-
-        export default function html(...args) {
-          return createTree(...args);
-        }
-      `,
-
-      './lib/util/parse.js': `
-        export default () => console.error('Runtime is not built with parsing');
-      `,
-
       './lib/util/performance.js': `
         export default () => () => {};
       `,

--- a/packages/diffhtml/test/util.js
+++ b/packages/diffhtml/test/util.js
@@ -7,7 +7,6 @@ import decodeEntities from '../lib/util/decode-entities';
 import escape from '../lib/util/escape';
 import parse from '../lib/util/parse';
 import _process from '../lib/util/process';
-import { namespace } from '../lib/util/svg';
 import { protectVTree, unprotectVTree, cleanMemory } from '../lib/util/memory';
 import makeMeasure from '../lib/util/make-measure';
 import Pool from '../lib/util/pool';
@@ -849,12 +848,6 @@ describe('Util', function() {
           }],
           attributes: {},
       });
-    });
-  });
-
-  describe('SVG', () => {
-    it('exports the SVG namespace', () => {
-      equal(namespace, 'http://www.w3.org/2000/svg');
     });
   });
 


### PR DESCRIPTION
- Better support for `props.children`. Fixes issues with multiple top level elements during a component render.

- Removed the unnecessary SVG file now

- Top level renders are fully supported as well as returning arrays from renders

- Babel transpiler works! Cool trick is to configure it with:

``` json
{
  "plugins": [
    ["transform-diffhtml", { "createTree": "html" }]
  ]
}
```

And then make sure you're loading the `runtime` build. This will allow you to write code like:

``` js
// Alias diffhtml to diffhtml/runtime or dist/es/runtime or dist/cjs/runtime or dist/diffhtml-runtime
import { innerHTML, html } from 'diffhtml';

function render() {
  return html`
    <div>Hello world</div>
   `;
}

innerHTML(document.body, render());
```

And have it neatly transpiled without needing to import `diff` in its entirety. It requires using the runtime build though which aliases `html` to `createTree`.