### PR TITLE
Add tasks keyed by name to Internals

### DIFF
--- a/packages/diffhtml/lib/index.js
+++ b/packages/diffhtml/lib/index.js
@@ -1,4 +1,5 @@
 import createTree from './tree/create';
+import createNode from './node/create';
 import parseNewTree from './tasks/parse-new-tree';
 import reconcileTrees from './tasks/reconcile-trees';
 import internals from './util/internals';
@@ -33,7 +34,7 @@ const api = {
 // changes and will supply fallbacks when APIs change.
 //
 // Note: The HTML parser is only available in this mode.
-const Internals = Object.assign(internals, api, { parse, defaultTasks, tasks });
+const Internals = Object.assign(internals, api, { parse, defaultTasks, tasks, createNode });
 
 // Attach a circular reference to `Internals` for ES/CJS builds.
 api.Internals = Internals;

--- a/packages/diffhtml/lib/index.js
+++ b/packages/diffhtml/lib/index.js
@@ -5,7 +5,7 @@ import internals from './util/internals';
 import parse from './util/parse';
 import innerHTML from './inner-html';
 import outerHTML from './outer-html';
-import { defaultTasks } from './transaction';
+import { defaultTasks, tasks } from './transaction';
 import html from './html';
 import release from './release';
 import use from './use';
@@ -33,7 +33,7 @@ const api = {
 // changes and will supply fallbacks when APIs change.
 //
 // Note: The HTML parser is only available in this mode.
-const Internals = Object.assign(internals, api, { parse, defaultTasks });
+const Internals = Object.assign(internals, api, { parse, defaultTasks, tasks });
 
 // Attach a circular reference to `Internals` for ES/CJS builds.
 api.Internals = Internals;

--- a/packages/diffhtml/lib/runtime.js
+++ b/packages/diffhtml/lib/runtime.js
@@ -2,7 +2,7 @@ import createTree from './tree/create';
 import internals from './util/internals';
 import innerHTML from './inner-html';
 import outerHTML from './outer-html';
-import { defaultTasks } from './transaction';
+import { defaultTasks, tasks } from './transaction';
 import release from './release';
 import use from './use';
 import { addTransitionState, removeTransitionState } from './transition';
@@ -27,7 +27,7 @@ const api = {
 // leverage internal APIs that are not part of the public API. There are no
 // promises that this will not break in the future. We will attempt to minimize
 // changes and will supply fallbacks when APIs change.
-const Internals = Object.assign(internals, api, { defaultTasks });
+const Internals = Object.assign(internals, api, { defaultTasks, tasks });
 
 // Attach a circular reference to `Internals` for ES/CJS builds.
 api.Internals = Internals;

--- a/packages/diffhtml/lib/runtime.js
+++ b/packages/diffhtml/lib/runtime.js
@@ -1,4 +1,5 @@
 import createTree from './tree/create';
+import createNode from './node/create';
 import internals from './util/internals';
 import innerHTML from './inner-html';
 import outerHTML from './outer-html';
@@ -27,7 +28,7 @@ const api = {
 // leverage internal APIs that are not part of the public API. There are no
 // promises that this will not break in the future. We will attempt to minimize
 // changes and will supply fallbacks when APIs change.
-const Internals = Object.assign(internals, api, { defaultTasks, tasks });
+const Internals = Object.assign(internals, api, { defaultTasks, tasks, createNode });
 
 // Attach a circular reference to `Internals` for ES/CJS builds.
 api.Internals = Internals;

--- a/packages/diffhtml/lib/transaction.js
+++ b/packages/diffhtml/lib/transaction.js
@@ -14,6 +14,10 @@ export const defaultTasks = [
   schedule, shouldUpdate, reconcileTrees, syncTrees, patchNode, endAsPromise,
 ];
 
+export const tasks = {
+  schedule, shouldUpdate, reconcileTrees, syncTrees, patchNode, endAsPromise
+};
+
 export default class Transaction {
   static create(domNode, markup, options) {
     return new Transaction(domNode, markup, options);


### PR DESCRIPTION
This allows middleware to access a task without needing to know what
index the task is located at.