### PR TITLE
Improve static sync reliability

### DIFF
--- a/packages/babel-plugin-transform-diffhtml/dist/index.js
+++ b/packages/babel-plugin-transform-diffhtml/dist/index.js
@@ -7514,7 +7514,14 @@ exports.default = function (_ref) {
 
                 isDynamic = true;
               } else {
-                args.push(createTree, [t.stringLiteral('#text'), t.nullLiteral(), nodeValue]);
+                var id = path.scope.generateUidIdentifier('vtree');
+
+                path.scope.parent.push({
+                  id: id,
+                  init: t.callExpression(createTree, [t.stringLiteral('#text'), t.nullLiteral(), nodeValue])
+                });
+
+                args.replacement = id;
               }
             }
 
@@ -7526,9 +7533,9 @@ exports.default = function (_ref) {
 
           // Is a static node and never changes, so hoist createTree call.
           if (!isDynamic && isTopLevelStatic) {
-            var id = path.scope.generateUidIdentifier('vtree');
-            path.scope.parent.push({ id: id, init: callExpr });
-            statements[i].expression = id;
+            var _id = path.scope.generateUidIdentifier('vtree');
+            path.scope.parent.push({ id: _id, init: callExpr });
+            statements[i].expression = _id;
           } else {
             statements[i].expression = callExpr;
           }

--- a/packages/babel-plugin-transform-diffhtml/src/index.js
+++ b/packages/babel-plugin-transform-diffhtml/src/index.js
@@ -327,11 +327,18 @@ export default function({ types: t }) {
               isDynamic = true;
             }
             else {
-              args.push(createTree, [
-                t.stringLiteral('#text'),
-                t.nullLiteral(),
-                nodeValue
-              ]);
+              let id = path.scope.generateUidIdentifier('vtree');
+
+              path.scope.parent.push({
+                id,
+                init: t.callExpression(createTree, [
+                  t.stringLiteral('#text'),
+                  t.nullLiteral(),
+                  nodeValue,
+                ])
+              });
+
+              args.replacement = id;
             }
           }
 

--- a/packages/diffhtml-components/lib/component.js
+++ b/packages/diffhtml-components/lib/component.js
@@ -61,7 +61,9 @@ export default upgradeSharedClass(class Component {
     });
 
     if (process.env.NODE_ENV !== 'production') {
-      PropTypes.checkPropTypes(propTypes, props, 'prop', name);
+      if (PropTypes.checkPropTypes) {
+        PropTypes.checkPropTypes(propTypes, props, 'prop', name);
+      }
     }
 
     //keys(childContextTypes).forEach(prop => {

--- a/packages/diffhtml-components/lib/tasks/react-like-component.js
+++ b/packages/diffhtml-components/lib/tasks/react-like-component.js
@@ -129,16 +129,20 @@ reactLikeComponentTask.syncTreeHook = (oldTree, newTree) => {
           renderTree = oldInstance.render(props, oldInstance.state);
         }
       }
+      else if (instance && instance.render) {
+        renderTree = createTree(instance.render(props, instance.state));
+      }
       else {
-        renderTree = createTree
-          (instance && instance.render ? instance.render(props, instance.state) : newCtor(props)
-        );
+        renderTree = createTree(newCtor(props));
       }
 
+      // Nothing was rendered so continue.
       if (!renderTree) {
         continue;
       }
 
+      // Replace the rendered value into the new tree, if rendering a fragment
+      // this will inject the contents into the parent.
       if (renderTree.nodeType === 11) {
         newTree.childNodes = [...renderTree.childNodes];
 
@@ -147,8 +151,9 @@ reactLikeComponentTask.syncTreeHook = (oldTree, newTree) => {
           InstanceCache.set(oldTree, instance);
         }
       }
+      // If the rendered value is a single element use it as the root for
+      // diffing.
       else {
-        // Build a new tree from the render, and use this as the current tree.
         newTree.childNodes[i] = renderTree;
 
         if (instance) {

--- a/packages/diffhtml-components/lib/tasks/react-like-component.js
+++ b/packages/diffhtml-components/lib/tasks/react-like-component.js
@@ -97,17 +97,19 @@ export default function reactLikeComponentTask(transaction) {
 }
 
 reactLikeComponentTask.syncTreeHook = (oldTree, newTree) => {
+  const oldChildNodes = oldTree && oldTree.childNodes ;
+
   // Stateful components have a very limited API, designed to be fully
   // implemented by a higher-level abstraction. The only method ever called is
   // `render`. It is up to a higher level abstraction on how to handle the
   // changes.
   for (let i = 0; i < newTree.childNodes.length; i++) {
-    const oldChild = oldTree && oldTree.childNodes && oldTree.childNodes[i];
     const newChild = newTree.childNodes[i];
 
     // If incoming tree is a component, flatten down to tree for now.
     if (newChild && typeof newChild.rawNodeName === 'function') {
       const newCtor = newChild.rawNodeName;
+      const oldChild = oldChildNodes && oldChildNodes[i];
       const oldInstanceCache = InstanceCache.get(oldChild);
       const children = newChild.childNodes;
       const props = assign({}, newChild.attributes, { children });
@@ -154,9 +156,8 @@ reactLikeComponentTask.syncTreeHook = (oldTree, newTree) => {
           InstanceCache.set(renderTree, instance);
         }
       }
-
-      // Recursively update trees.
-      return newTree;
     }
   }
+
+  return newTree;
 };

--- a/packages/diffhtml-components/lib/web-component.js
+++ b/packages/diffhtml-components/lib/web-component.js
@@ -81,7 +81,9 @@ export default upgradeSharedClass(class WebComponent extends HTMLElement {
     });
 
     if (process.env.NODE_ENV !== 'production') {
-      PropTypes.checkPropTypes(propTypes, this.props, 'prop', name);
+      if (PropTypes.checkPropTypes) {
+        PropTypes.checkPropTypes(propTypes, this.props, 'prop', name);
+      }
     }
   }
 

--- a/packages/diffhtml-static-sync/README.md
+++ b/packages/diffhtml-static-sync/README.md
@@ -1,13 +1,14 @@
 # <±/> diffHTML Static Sync
 
-*Lightweight VDOM for entire HTML pages and CSS LiveReload.*
-
+*Static server that livereloads using VDOM on the entire page along with CSS.*
 Stable Version: 1.0.0-beta.4
 
-A static HTML server that monitors the folder it was executed in for changes
-and diffs them seamlessly into the browser without needing to reload the page.
-This includes all `<HTML>`, `<HEAD>`, and `<BODY>` tag changes as well.
-Provides smart CSS reloading, that instantly updates.
+Provides a static HTTP server that monitors the folder it was executed in for
+changes. Whenever a file changes, it is read from disk and sent to the page
+using WebSockets. This server injects a client-side handler which responds to
+this WebSocket event, and using diffHTML, diffs the contents seamlessly without
+needing to reload. This includes all `<HTML>`, `<HEAD>`, and `<BODY>` tag
+changes. Provides smart CSS reloading, that instantly updates.
 
 Takes a "just works" approach by automatically injecting the synchronization
 code.
@@ -38,3 +39,22 @@ shouldn't see any output just yet, but the command should appear to hang.
 
 Once you open your browser to: http://localhost:8000/ you should see the
 `index.html` file or a directory listing to chose from.
+
+Basic usage:
+
+``` sh
+λ diffhtml-static-sync .
+Open http://localhost:8000
+
+Waiting for changes ⣻ Socket connection established
+```
+
+## Markdown
+
+Markdown is supported out-of-the-box, browse them as you would normal HTML
+files. Name your markdown files with `index.markdown` or `index.md` to be
+picked up automatically in folders.
+
+## LiveReload
+
+By default any other file types are treated as a full page reload.

--- a/packages/diffhtml-static-sync/index.js
+++ b/packages/diffhtml-static-sync/index.js
@@ -7,7 +7,6 @@ if (require.main === module) {
 const { readFile, readFileSync } = require('fs');
 const { basename, join } = require('path');
 const { watch } = require('chokidar');
-const express = require('express');
 const getSocket = require('./lib/socket');
 
 exports.clientScript = require('./lib/util/client-script');

--- a/packages/diffhtml-static-sync/lib/socket.js
+++ b/packages/diffhtml-static-sync/lib/socket.js
@@ -1,6 +1,11 @@
 const engine = require('engine.io');
 const server = engine.listen(process.env.WS_PORT || 54321);
 
-module.exports = new Promise(resolve => server.on('connection', resolve));
+const sockets = new Set();
+
+module.exports = new Promise(resolve => server.on('connection', socket => {
+  sockets.add(socket);
+  resolve(sockets);
+}));
 
 process.on('exit', () => server.close());

--- a/packages/diffhtml-static-sync/lib/socket.js
+++ b/packages/diffhtml-static-sync/lib/socket.js
@@ -2,8 +2,15 @@ const engine = require('engine.io');
 const server = engine.listen(process.env.WS_PORT || 54321);
 
 const sockets = new Set();
+const yellow = '\x1B[33m';
+const reset = '\x1B[m';
+const quiet = process.argv.includes('--quiet');
 
 module.exports = new Promise(resolve => server.on('connection', socket => {
+  if (!quiet) {
+    console.log(`${yellow}Socket connection established${reset}`);
+  }
+
   sockets.add(socket);
   resolve(sockets);
 }));

--- a/packages/diffhtml-static-sync/lib/util/client-script.js
+++ b/packages/diffhtml-static-sync/lib/util/client-script.js
@@ -2,4 +2,8 @@ const { readFileSync } = require('fs');
 const { join } = require('path');
 const escape = require('./escape');
 
-module.exports = escape(readFileSync(join(__dirname, '../../dist/sync.js')));
+Object.defineProperty(module, 'exports', {
+  get() {
+    return escape(readFileSync(join(__dirname, '../../dist/sync.js')));
+  }
+});

--- a/packages/diffhtml-static-sync/lib/watch.js
+++ b/packages/diffhtml-static-sync/lib/watch.js
@@ -1,11 +1,21 @@
 const { readFile } = require('fs');
 const { basename, extname, join } = require('path');
+const { Spinner } = require('cli-spinner');
 const { watch } = require('chokidar');
+const marked = require('marked');
 const express = require('express');
 const getSocket = require('./socket');
 const clientScript = require('./util/client-script');
 
 const CWD = process.cwd();
+
+// CLI Colors
+const yellow = '\x1B[33m';
+const blue = '\x1B[34m';
+const gray = '\x1B[37m';
+const green = '\x1B[32m';
+const reset = '\x1B[m';
+const quiet = process.argv.includes('--quiet');
 
 const webServer = express();
 const watcher = watch(CWD, {
@@ -13,18 +23,29 @@ const watcher = watch(CWD, {
   persistent: true,
 });
 
+const read = path => new Promise((res, rej) => readFile(path, (err, buffer) => {
+  if (err) { rej(err); } else { res(buffer); }
+}));
+
+const formatMarkdown = markup => `<html>
+  <body>
+    ${marked(String(markup))}
+  </body>
+</html>`;
+
 webServer.use('/', (req, res, next) => {
   const ext = extname(req.url);
-  const isRoot = req.url === '' || req.url === '/';
+  const isRoot = req.url === '' || req.url.slice(-1) === '/';
+  const path = root => isRoot ? root : req.url;
 
-  if (isRoot || ext === '.html') {
-    const path = isRoot ? 'index.html' : req.url;
-    readFile(join(CWD, path), (err, buffer) => {
-      res.send(`
+  if (isRoot || ext === '.html' || ext === 'md' || ext === 'markdown') {
+    read(path('index.html'))
+      .catch(() => read('index.md').then(formatMarkdown))
+      .catch(() => read('index.markdown').then(formatMarkdown))
+      .then(buffer => res.send(`
         ${String(buffer)}
         <script>${clientScript}</script>
-      `);
-    });
+      `));
   }
   else {
     next();
@@ -34,22 +55,37 @@ webServer.use('/', (req, res, next) => {
 webServer.use(express.static(CWD));
 
 webServer.listen(process.env.SERVER_PORT || 8000, () => {
-  console.log('Listening at http://localhost:8000');
+  if (!quiet) {
+    console.log(`Open http://localhost:8000\n`);
+  }
 
   getSocket.then(sockets => {
-    console.log('Socket connection established, monitoring files...');
-
     watcher.on('change', path => {
-      console.log(`${path} changed`);
+      if (!quiet) {
+        console.log(`${green}${path} changed${reset}`);
+      }
 
       readFile(path, (err, buffer) => {
         sockets.forEach(socket => {
-          socket.send(JSON.stringify({
+          const state = {
             file: path.slice(CWD.length + 1),
             markup: String(buffer),
-          }));
+            quiet,
+          };
+
+          if (state.file.includes('.md') || state.file.includes('.markdown')) {
+            state.file = state.file.replace(/(\.md|\.markdown)/g, '.html');
+            state.markup = formatMarkdown(state.markup);
+          }
+
+          socket.send(JSON.stringify(state));
         });
       });
     });
   });
 });
+
+const spinner = new Spinner(`${gray}Waiting for changes %s${reset} `);
+
+spinner.setSpinnerString(27);
+spinner.start();

--- a/packages/diffhtml-static-sync/package.json
+++ b/packages/diffhtml-static-sync/package.json
@@ -16,9 +16,11 @@
   "license": "MIT",
   "dependencies": {
     "chokidar": "^1.6.1",
+    "cli-spinner": "^0.2.6",
     "diffhtml": "^1.0.0-beta.4",
     "engine.io": "^1.8.1",
-    "express": "^4.14.0"
+    "express": "^4.14.0",
+    "marked": "^0.3.6"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.18.0",

--- a/packages/diffhtml-static-sync/sync.js
+++ b/packages/diffhtml-static-sync/sync.js
@@ -3,14 +3,61 @@ import { Socket } from 'engine.io-client';
 
 process.env.NODE_ENV = 'production';
 
-const socket = new Socket('ws://localhost:54321');
+let interval = null;
+const domNodes = new Map();
 
-socket.on('open', () => {
-  socket.on('message', message => {
-    const { file, markup } = JSON.parse(message);
+function open() {
+  clearInterval(interval);
 
-    if (file === true || location.pathname.slice(1) === file) {
-      outerHTML(document.documentElement, markup || '<html></html>')
-    }
+  const socket = new Socket('ws://localhost:54321');
+
+  socket.on('open', () => {
+    console.log('Socket connected');
+
+    socket.on('message', message => {
+      release(document.documentElement);
+
+      const { file, markup } = JSON.parse(message);
+
+      console.log(`${file} changed`);
+
+      // Handle CSS files.
+      if (file.includes('.css')) {
+        const queryString = `?sync=${Date.now()}`;
+        const domNode = document.querySelector(`link[href='${file}']`) || domNodes.get(file);
+
+        if (domNode) {
+          console.log(`${file} found on page, reloading`);
+          domNode.href = domNode.href.replace(/\?.*|$/, queryString);
+          domNodes.set(file, domNode);
+        }
+        // Reload all stylesheets since we want to be sure everything is updated.
+        else {
+          [...document.querySelectorAll('link')].forEach(domNode => {
+            const queryString = `?sync=${Date.now()}`;
+            domNode.href = domNode.href.replace(/\?.*|$/, queryString);
+          });
+        }
+      }
+
+      const path = location.pathname.slice(1) || 'index.html';
+
+      if (file === true || path === file) {
+        console.log(`Updated with: ${markup}`);
+        outerHTML(document.documentElement, markup || '<html></html>')
+      }
+    });
   });
-});
+
+  socket.on('close', () => {
+    console.log('Socket closed, attempting to reopen every 2 seconds');
+
+    interval = setInterval(() => open(), 2000);
+  });
+
+  socket.on('error', () => {
+    console.log('Socket errored');
+  });
+}
+
+open();

--- a/packages/diffhtml/lib/tasks/patch-node.js
+++ b/packages/diffhtml/lib/tasks/patch-node.js
@@ -9,11 +9,9 @@ import patchNode from '../node/patch';
 export default function patch(transaction) {
   const { domNode, state, state: { measure }, patches } = transaction;
   const { promises = [] } = transaction;
+  const { namespaceURI = '', nodeName } = domNode;
 
-  // Is the root SVG?
-  state.isSVG = transaction.oldTree.nodeName === 'svg';
-
-  // Set the ownerDocument.
+  state.isSVG = nodeName.toLowerCase() === 'svg' || namespaceURI.includes('svg');
   state.ownerDocument = domNode.ownerDocument || document;
 
   measure('patch node');

--- a/packages/diffhtml/lib/tree/sync.js
+++ b/packages/diffhtml/lib/tree/sync.js
@@ -46,15 +46,6 @@ export default function syncTree(oldTree, newTree, patches) {
         if (vTree.key) {
           map.set(vTree.key, vTree);
         }
-        else if (process.env.NODE_ENV !== 'production') {
-          if (map.size && vTree.nodeType === 1) {
-            throw new Error(
-            `Missing \`key\` all siblings must supply this attribute.
-
-Virtual Element: ${JSON.stringify(vTree, null, 2)}`
-            );
-          }
-        }
       }
     }
   }

--- a/packages/diffhtml/package.json
+++ b/packages/diffhtml/package.json
@@ -18,7 +18,7 @@
     "build-esm": "NODE_ENV=esm babel lib -d dist/es",
     "build-main": "NODE_ENV=umd rollup -c rollup.main.config.js",
     "build-runtime": "NODE_ENV=umd rollup -c rollup.runtime.config.js",
-    "build-main-min": "NODE_ENV=min rollup -c rollup.runtime.config.js && uglifyjs dist/diffhtml.js -o dist/diffhtml.min.js -m -c",
+    "build-main-min": "NODE_ENV=min rollup -c rollup.main.config.js && uglifyjs dist/diffhtml.min.js -o dist/diffhtml.min.js -m -c",
     "build-runtime-min": "NODE_ENV=min rollup -c rollup.runtime.config.js && uglifyjs dist/diffhtml-runtime.min.js -o dist/diffhtml-runtime.min.js -m -c",
     "watch-main": "NODE_ENV=umd rollup -c rollup.main.config.js -w",
     "watch-runtime": "NODE_ENV=umd rollup -c rollup.runtime.main.config.js -w",


### PR DESCRIPTION
- Added verbose logging
- Retry logic every 2 seconds
- Release the documentElement before patching, forcing a complete memory dump and recreation. While diffHTML should handle this stuff just fine, this seems like a safer way to handle potentially busted markup.
- Maintain list of sockets instead of just the first one
- LiveReload CSS