### PR TITLE
Expose Component internals, respect rawNodeName

### DIFF
--- a/packages/babel-plugin-transform-diffhtml/dist/index.js
+++ b/packages/babel-plugin-transform-diffhtml/dist/index.js
@@ -7439,17 +7439,13 @@ exports.default = function (_ref) {
             return;
           }
 
-          var nodeName = childNode.properties.filter(function (property) {
-            return property.key.value === 'nodeName';
-          })[0].value;
-
           // The nodeName without `toLowerCase()` being called on it.
           var rawNodeName = childNode.properties.filter(function (property) {
             return property.key.value === 'rawNodeName';
-          })[0].value.value;
+          })[0].value;
 
           // Extract
-          var identifierIsInScope = path.scope.hasBinding(rawNodeName);
+          var identifierIsInScope = path.scope.hasBinding(rawNodeName.value);
 
           var nodeType = childNode.properties.filter(function (property) {
             return property.key.value === 'nodeType';
@@ -7493,9 +7489,9 @@ exports.default = function (_ref) {
               isDynamic = true;
             }
 
-            var token = rawNodeName.match(tokenEx);
+            var token = rawNodeName.value.match(tokenEx);
 
-            args.push(createTree, [identifierIsInScope ? t.identifier(rawNodeName) : token ? supplemental.tags[token[1]] : nodeName, attributes, t.arrayExpression(_expressions.map(function (expr) {
+            args.push(createTree, [identifierIsInScope ? t.identifier(rawNodeName.value) : token ? supplemental.tags[token[1]] : rawNodeName, attributes, t.arrayExpression(_expressions.map(function (expr) {
               return expr.expression;
             }))]);
           }

--- a/packages/babel-plugin-transform-diffhtml/src/index.js
+++ b/packages/babel-plugin-transform-diffhtml/src/index.js
@@ -245,17 +245,13 @@ export default function({ types: t }) {
             return;
           }
 
-          const nodeName = childNode.properties.filter(property => {
-            return property.key.value === 'nodeName';
-          })[0].value;
-
           // The nodeName without `toLowerCase()` being called on it.
           const rawNodeName = childNode.properties.filter(property => {
             return property.key.value === 'rawNodeName';
-          })[0].value.value;
+          })[0].value;
 
           // Extract
-          const identifierIsInScope = path.scope.hasBinding(rawNodeName);
+          const identifierIsInScope = path.scope.hasBinding(rawNodeName.value);
 
           const nodeType = childNode.properties.filter(property => {
             return property.key.value === 'nodeType';
@@ -302,10 +298,10 @@ export default function({ types: t }) {
               isDynamic = true;
             }
 
-            const token = rawNodeName.match(tokenEx);
+            const token = rawNodeName.value.match(tokenEx);
 
             args.push(createTree, [
-              identifierIsInScope ? t.identifier(rawNodeName) : (token ? supplemental.tags[token[1]] : nodeName),
+              identifierIsInScope ? t.identifier(rawNodeName.value) : (token ? supplemental.tags[token[1]] : rawNodeName),
               attributes,
               t.arrayExpression(expressions.map(expr => expr.expression)),
             ]);

--- a/packages/diffhtml-components/lib/index.js
+++ b/packages/diffhtml-components/lib/index.js
@@ -1,3 +1,6 @@
 export { default as Component } from './component';
 export { default as WebComponent } from './web-component';
 export { default as PropTypes } from 'prop-types';
+import * as Internals from './util/internals';
+
+export { Internals };

--- a/packages/diffhtml-components/lib/tasks/react-like-component.js
+++ b/packages/diffhtml-components/lib/tasks/react-like-component.js
@@ -124,6 +124,7 @@ reactLikeComponentTask.syncTreeHook = (oldTree, newTree) => {
 
       if (oldInstance) {
         oldInstance.componentWillReceiveProps(props);
+        oldInstance.props = props;
 
         if (oldInstance.shouldComponentUpdate()) {
           renderTree = oldInstance.render(props, oldInstance.state);

--- a/packages/diffhtml-components/lib/util/caches.js
+++ b/packages/diffhtml-components/lib/util/caches.js
@@ -1,2 +1,2 @@
-export const ComponentTreeCache = new WeakMap();
-export const InstanceCache = new WeakMap();
+export const ComponentTreeCache = new Map();
+export const InstanceCache = new Map();

--- a/packages/diffhtml-components/lib/util/internals.js
+++ b/packages/diffhtml-components/lib/util/internals.js
@@ -1,0 +1,3 @@
+import * as caches from './caches';
+
+export { caches };

--- a/packages/diffhtml-components/lib/web-component.js
+++ b/packages/diffhtml-components/lib/web-component.js
@@ -108,6 +108,7 @@ export default upgradeSharedClass(class WebComponent extends HTMLElement {
     if (this.shadowRoot && !Debounce.has(this)) {
       const nextProps = createProps(this);
       this.componentWillReceiveProps(nextProps);
+      this.props = nextProps;
       this[$$render]();
 
       Debounce.set(this, setTimeout(() => {

--- a/packages/diffhtml-static-sync/sync.js
+++ b/packages/diffhtml-static-sync/sync.js
@@ -56,7 +56,7 @@ function open() {
         let retVal = false;
 
         staticSyncHandlers.forEach(fn => {
-          retVal = retVal || fn({ file, markup });
+          retVal = retVal || fn({ file, markup, quiet });
         });
 
         if (retVal) {
@@ -84,6 +84,8 @@ function open() {
             domNode.href = domNode.href.replace(/\?.*|$/, queryString);
           });
         }
+
+        return;
       }
 
       const path = location.pathname.slice(1) || 'index.html';

--- a/packages/diffhtml/lib/node/create.js
+++ b/packages/diffhtml/lib/node/create.js
@@ -28,7 +28,7 @@ export default function createNode(vTree, ownerDocument = document, isSVG) {
     return existingNode;
   }
 
-  const { nodeName, childNodes = [] } = vTree;
+  const { nodeName, rawNodeName = nodeName, childNodes = [] } = vTree;
   isSVG = isSVG || nodeName === 'svg';
 
   // Will vary based on the properties of the VTree.
@@ -54,11 +54,11 @@ export default function createNode(vTree, ownerDocument = document, isSVG) {
     }
     // Support SVG.
     else if (isSVG) {
-      domNode = ownerDocument.createElementNS(namespace, nodeName);
+      domNode = ownerDocument.createElementNS(namespace, rawNodeName);
     }
     // If not a Text or SVG Node, then create with the standard method.
     else {
-      domNode = ownerDocument.createElement(nodeName);
+      domNode = ownerDocument.createElement(rawNodeName);
     }
   }
 


### PR DESCRIPTION
When creating new elements I found that SVG foreignObject is case
sensitive. We need to keep this in mind when creating elements.