### PR TITLE
Add test case for parser bug

### DIFF
--- a/packages/diffhtml/lib/util/parse.js
+++ b/packages/diffhtml/lib/util/parse.js
@@ -273,7 +273,7 @@ export default function parse(html, supplemental, options = {}) {
         }
 
         const newText = html.slice(match.index + match[0].length, index);
-        interpolateValues(currentParent, newText.trim(), supplemental);
+        interpolateValues(currentParent, newText, supplemental);
       }
     }
 

--- a/packages/diffhtml/test/util.js
+++ b/packages/diffhtml/test/util.js
@@ -851,28 +851,28 @@ describe('Util', function() {
     });
 
     it('will correctly parse hard return text node', () => {
-        const vTree = parse(`<code>
+      const vTree = parse(`<code>
 </code>`).childNodes[0];
 
-        deepEqual(vTree, {
-            "attributes": {},
-            "childNodes": [
-                {
-                    "rawNodeName": "#text",
-                    "nodeName": "#text",
-                    "nodeValue": "\n",
-                    "nodeType": 3,
-                    "key": "",
-                    "childNodes": [],
-                    "attributes": {}
-                }
-            ],
+      deepEqual(vTree, {
+        "attributes": {},
+        "childNodes": [
+          {
+            "rawNodeName": "#text",
+            "nodeName": "#text",
+            "nodeValue": "\n",
+            "nodeType": 3,
             "key": "",
-            "nodeName": "code",
-            "nodeType": 1,
-            "nodeValue": "",
-            "rawNodeName": "code"
-        });
+            "childNodes": [],
+            "attributes": {}
+          }
+        ],
+        "key": "",
+        "nodeName": "code",
+        "nodeType": 1,
+        "nodeValue": "",
+        "rawNodeName": "code"
+      });
     });
   });
 

--- a/packages/diffhtml/test/util.js
+++ b/packages/diffhtml/test/util.js
@@ -849,6 +849,31 @@ describe('Util', function() {
           attributes: {},
       });
     });
+
+    it('will correctly parse hard return text node', () => {
+        const vTree = parse(`<code>
+</code>`).childNodes[0];
+
+        deepEqual(vTree, {
+            "attributes": {},
+            "childNodes": [
+                {
+                    "rawNodeName": "#text",
+                    "nodeName": "#text",
+                    "nodeValue": "\n",
+                    "nodeType": 3,
+                    "key": "",
+                    "childNodes": [],
+                    "attributes": {}
+                }
+            ],
+            "key": "",
+            "nodeName": "code",
+            "nodeType": 1,
+            "nodeValue": "",
+            "rawNodeName": "code"
+        });
+    });
   });
 
   describe('Pool', () => {


### PR DESCRIPTION
This should parse the hard return as a child of the `code` element,
but instead produces a vTree with no children.

Currently just a test case.