### PR TITLE
Fix syncTrees from generating too many patches

### DIFF
--- a/packages/diffhtml/lib/tree/sync.js
+++ b/packages/diffhtml/lib/tree/sync.js
@@ -71,6 +71,9 @@ export default function syncTree(oldTree, newTree, patches, parentTree, specialC
     // then splice it into the parent (if it exists) and run a sync.
     if (retVal && retVal !== newTree) {
       newTree.childNodes = [].concat(retVal);
+      // Use the oldTree (if we have it) to short-circuit renders if the middleware
+      // returns oldTree itself. This keeps syncTree from generating patches
+      // for attribute changes that don't differ from the current state.
       syncTree(oldTree !== empty ? oldTree : null, retVal, patches, newTree);
       newTree = retVal;
     }

--- a/packages/diffhtml/lib/tree/sync.js
+++ b/packages/diffhtml/lib/tree/sync.js
@@ -71,7 +71,7 @@ export default function syncTree(oldTree, newTree, patches, parentTree, specialC
     // then splice it into the parent (if it exists) and run a sync.
     if (retVal && retVal !== newTree) {
       newTree.childNodes = [].concat(retVal);
-      syncTree(null, retVal, patches, newTree);
+      syncTree(oldTree !== empty ? oldTree : null, retVal, patches, newTree);
       newTree = retVal;
     }
   });


### PR DESCRIPTION
This is a reversion of the change found in
e282dbc78e51bb12d8e39ecc4db63d733f084cf0 and a test to ensure
the prevention of future regressions. [See comments.](https://github.com/tbranyen/diffhtml/commit/e282dbc78e51bb12d8e39ecc4db63d733f084cf0#commitcomment-23617776)