### PR TITLE
Fixed regex for special cases

### DIFF
--- a/packages/diffhtml/lib/util/parse.js
+++ b/packages/diffhtml/lib/util/parse.js
@@ -7,7 +7,7 @@ import process from './process';
 
 const hasNonWhitespaceEx = /\S/;
 const doctypeEx = /<!.*>/i;
-const attrEx = /\b([_a-z][_a-z0-9\-]*)\s*(=\s*("([^"]+)"|'([^']+)'|(\S+)))?/ig;
+const attrEx = /\b([_a-z][_a-z0-9\-:]*)\s*(=\s*("([^"]+)"|'([^']+)'|(\S+)))?/ig;
 const spaceEx = /[^ ]/;
 const tokenEx = /__DIFFHTML__([^_]*)__/;
 const tagEx =


### PR DESCRIPTION
Now allows html attributes that use colons(e.g. v-bind:variable="x") to be correctly parsed