### PR TITLE
Greatly improve render-to-string

### DIFF
--- a/packages/diffhtml-components/lib/web-component.js
+++ b/packages/diffhtml-components/lib/web-component.js
@@ -31,7 +31,7 @@ const createProps = (domNode, props = {}) => {
 // Creates the `component.state` object.
 const createState = (domNode, newState) => assign({}, domNode.state, newState);
 
-class WebComponent extends HTMLElement {
+class WebComponent extends root.HTMLElement {
   static get observedAttributes() {
     return getObserved(this).map(key => key.toLowerCase());
   }
@@ -45,7 +45,7 @@ class WebComponent extends HTMLElement {
   }
 
   constructor(props, context) {
-    if (HTMLElement === nullFunc) {
+    if (root.HTMLElement === nullFunc) {
       throw new Error('Custom Elements require a valid browser environment');
     }
 

--- a/packages/diffhtml-render-to-string/README.md
+++ b/packages/diffhtml-render-to-string/README.md
@@ -3,7 +3,11 @@
 Stable Version: 1.0.0-beta.9
 
 Use with diffHTML to render your Virtual Trees to strings. This is useful for
-server-side rendering and testing.
+server-side rendering and testing. This works very similar to `outerHTML` and
+will even accept all the same markup inputs as that API.
+
+All middleware should work if it can run under Node.js. For instnace you can
+use React-like Components by importing from diffhtml-components.
 
 ##### Installation
 
@@ -15,7 +19,7 @@ npm install diffhtml-render-to-string
 
 ``` javascript
 import { html } from 'diffhtml';
-import renderToString from 'diffhtml-render-to-string';
+import { renderToString } from 'diffhtml-render-to-string';
 
 const markup = renderToString(html`
   <div>Hello world</div>
@@ -25,5 +29,25 @@ const markup = renderToString(html`
 res.send(markup);
 ```
 
-This will automatically invoke and render React-like Components. Web Components
-cannot be hydrated since they are rendered into the Shadow DOM.
+##### Example components
+
+``` javascript
+import { html } from 'diffhtml';
+import { Component } from 'diffhtml-components';
+import { renderToString } from 'diffhtml-render-to-string';
+
+class MyComponent extends Component {
+  render({ message }) {
+    return html`
+      <p>${message}</p>
+    `;
+  }
+}
+
+const markup = renderToString(html`
+  <${MyComponent} message="Hello world" />
+`);
+
+// Use with something like express to send to the client.
+res.send(markup);
+```

--- a/packages/diffhtml-render-to-string/index.js
+++ b/packages/diffhtml-render-to-string/index.js
@@ -1,25 +1,13 @@
-const { use, Internals, createTree, innerHTML } = require('diffhtml');
-
-// Simple helper to make a DOM-like object.
-const makeDomNode = (props) => ({
-  ...props,
-
-  childNodes: [],
-  parentNode: {},
-
-  appendChild(node) {
-    this.childNodes.push(node);
-  }
-});
+const { use, html, Internals, createTree, outerHTML } = require('diffhtml');
+const { makeDOMNode } = require('quick-dom-node');
+const { keys } = Object;
 
 // Apply a transformation function against the Nodes to produce a string of
 // markup.
-use({
-  createNodeHook(vTree) {
-    return makeDomNode(vTree);
-  },
-});
+use({ createNodeHook: vTree => makeDOMNode(vTree) });
 
+// Use the same tasks for every run. Maybe in the future we'll allow for
+// passing custom tasks.
 const tasks = new Set(Internals.defaultTasks);
 
 // Remove incompatible tasks, and replace them with serialization-compatible
@@ -47,25 +35,46 @@ tasks.add(function reconcileTrees(transaction) {
   transaction.oldTree = domNode;
 
   // Create a fake, but fast DOM node, replacing the VTree passed in.
-  transaction.domNode = makeDomNode(domNode);
+  transaction.domNode = makeDOMNode(domNode);
 });
 
 // Now that the reconcilation phase has been modified, proceed as normal.
 tasks.add(Internals.tasks.syncTrees);
-tasks.add(Internals.tasks.endAsPromise);
 
-module.exports = function renderToString(vTree) {
-  const oldTree = createTree(vTree.rawNodeName);
+// Return the string.
+tasks.add(function endAsString(transaction) {
+  return serializeVTree(transaction.oldTree);
+});
 
-  innerHTML(oldTree, vTree, {
-    tasks: [...tasks],
-  });
+/**
+ * renderToString
+ *
+ * Works like outerHTML by rendering a VTree and returning the source. This
+ * will accept any input that `outerHTML` normally accepts. This is a true
+ * render, but omits the DOM patching task.
+ *
+ * @param {any} markup Can be a diffHTML VTree object or string of HTML
+ * @return {String} of rendered markup representing the input rendered
+ */
+module.exports = function renderToString(markup, options = {}) {
+  const parseHTML = options.strict ? html.strict : html;
+  const newTree = typeof markup === 'string' ? parseHTML(markup) : markup;
+  const oldTree = createTree(newTree.rawNodeName);
 
-  return serializeVTree(oldTree);
+  return outerHTML(oldTree, newTree, { tasks: [...tasks], options });
 }
 
+/**
+ * serializeAttributes
+ *
+ * Takes in a diffHTML VTree attributes object and turns it into a key=value
+ * string.
+ *
+ * @param {Object} attributes
+ * @return {String}
+ */
 function serializeAttributes(attributes) {
-  const attrs = Object.keys(attributes);
+  const attrs = keys(attributes);
 
   return attrs.length ? ' ' + attrs.map((keyName, i) => {
     const value = attributes[keyName];
@@ -76,10 +85,20 @@ function serializeAttributes(attributes) {
   }).join(' ') : '';
 }
 
+/**
+ * serializeVTree
+ *
+ * Takes in a diffHTML VTree object and turns it into a string of HTML.
+ *
+ * @param {Object} vTree
+ * @return {String}
+ */
 function serializeVTree(vTree) {
-  let output = '';
   const { attributes, childNodes } = vTree;
 
+  let output = '';
+
+  // Document fragment.
   if (vTree.nodeType === 11) {
     vTree.childNodes.forEach(childNode => {
       output += serializeVTree(childNode);
@@ -93,7 +112,7 @@ function serializeVTree(vTree) {
   else if (vTree.nodeType === 3) {
     output += vTree.nodeValue;
   }
-  // Nest elements.
+  // Presentational DOM Node.
   else if (vTree.childNodes.length) {
     output += `<${vTree.nodeName}${serializeAttributes(vTree.attributes)}>${vTree.childNodes.map(childNode => `${serializeVTree(childNode)}`).join('')}</${vTree.nodeName}>`;
   }

--- a/packages/diffhtml-render-to-string/index.js
+++ b/packages/diffhtml-render-to-string/index.js
@@ -56,7 +56,7 @@ tasks.add(function endAsString(transaction) {
  * @param {any} markup Can be a diffHTML VTree object or string of HTML
  * @return {String} of rendered markup representing the input rendered
  */
-module.exports = function renderToString(markup, options = {}) {
+exports.renderToString = function renderToString(markup, options = {}) {
   const parseHTML = options.strict ? html.strict : html;
   const newTree = typeof markup === 'string' ? parseHTML(markup) : markup;
   const oldTree = createTree(newTree.rawNodeName);

--- a/packages/diffhtml-render-to-string/index.js
+++ b/packages/diffhtml-render-to-string/index.js
@@ -1,4 +1,70 @@
-function renderAttributes(attributes) {
+const { use, Internals, createTree, innerHTML } = require('diffhtml');
+
+// Simple helper to make a DOM-like object.
+const makeDomNode = (props) => ({
+  ...props,
+
+  childNodes: [],
+  parentNode: {},
+
+  appendChild(node) {
+    this.childNodes.push(node);
+  }
+});
+
+// Apply a transformation function against the Nodes to produce a string of
+// markup.
+use({
+  createNodeHook(vTree) {
+    return makeDomNode(vTree);
+  },
+});
+
+const tasks = new Set(Internals.defaultTasks);
+
+// Remove incompatible tasks, and replace them with serialization-compatible
+// functions.
+tasks.delete(Internals.tasks.reconcileTrees);
+tasks.delete(Internals.tasks.syncTrees);
+tasks.delete(Internals.tasks.patchNode);
+tasks.delete(Internals.tasks.endAsPromise);
+
+// Add a new reconcile trees function to ensure we are diffing against a tree
+// instead of DOM Node.
+tasks.add(function reconcileTrees(transaction) {
+  const { domNode, markup, options } = transaction;
+
+  // If we are in a render transaction where no markup was previously parsed
+  // then reconcile trees will attempt to create a tree based on the incoming
+  // markup (JSX/html/etc).
+  if (!transaction.newTree) {
+    transaction.newTree = createTree(markup);
+  }
+
+  // Associate the old tree with this brand new transaction. Always ensure that
+  // diffing happens at the root level. This avoids the unnecessary REPLACE
+  // operation that would normally occur under `innerHTML`.
+  transaction.oldTree = domNode;
+
+  // Create a fake, but fast DOM node, replacing the VTree passed in.
+  transaction.domNode = makeDomNode(domNode);
+});
+
+// Now that the reconcilation phase has been modified, proceed as normal.
+tasks.add(Internals.tasks.syncTrees);
+tasks.add(Internals.tasks.endAsPromise);
+
+module.exports = function renderToString(vTree) {
+  const oldTree = createTree(vTree.rawNodeName);
+
+  innerHTML(oldTree, vTree, {
+    tasks: [...tasks],
+  });
+
+  return serializeVTree(oldTree);
+}
+
+function serializeAttributes(attributes) {
   const attrs = Object.keys(attributes);
 
   return attrs.length ? ' ' + attrs.map((keyName, i) => {
@@ -10,34 +76,18 @@ function renderAttributes(attributes) {
   }).join(' ') : '';
 }
 
-function renderToString(vTree) {
+function serializeVTree(vTree) {
   let output = '';
-  const { attributes, childNodes, rawNodeName: Constructor } = vTree;
-  const props = Object.assign({}, attributes);
+  const { attributes, childNodes } = vTree;
 
-  // Component.
-  if (typeof Constructor === 'function') {
-    const canNew = Constructor.prototype && Constructor.prototype.render;
-    const { defaultProps = {} } = Constructor;
-
-    props.children = childNodes;
-
-    Object.keys(defaultProps).forEach(propName => {
-      props[propName] = props[propName] !== undefined ? props[propName] : defaultProps[propName];
-    });
-
-    const newTree = canNew ? new Constructor(props).render(props) : Constructor(props);
-
-    output += renderToString(newTree);
-  }
-  else if (vTree.nodeType === 11) {
+  if (vTree.nodeType === 11) {
     vTree.childNodes.forEach(childNode => {
-      output += renderToString(childNode);
+      output += serializeVTree(childNode);
     });
   }
   // Empty element.
   else if (!(vTree.childNodes.length) && vTree.nodeType === 1) {
-    output += `<${vTree.nodeName}${renderAttributes(vTree.attributes)}></${vTree.nodeName}>`;
+    output += `<${vTree.nodeName}${serializeAttributes(vTree.attributes)}></${vTree.nodeName}>`;
   }
   // Text Nodes.
   else if (vTree.nodeType === 3) {
@@ -45,10 +95,8 @@ function renderToString(vTree) {
   }
   // Nest elements.
   else if (vTree.childNodes.length) {
-    output += `<${vTree.nodeName}${renderAttributes(vTree.attributes)}>${vTree.childNodes.map(childNode => `${renderToString(childNode)}`).join('')}</${vTree.nodeName}>`;
+    output += `<${vTree.nodeName}${serializeAttributes(vTree.attributes)}>${vTree.childNodes.map(childNode => `${serializeVTree(childNode)}`).join('')}</${vTree.nodeName}>`;
   }
 
   return output;
 }
-
-module.exports = renderToString;

--- a/packages/diffhtml-render-to-string/package.json
+++ b/packages/diffhtml-render-to-string/package.json
@@ -9,7 +9,11 @@
   },
   "devDependencies": {
     "diffhtml": "^1.0.0-beta.10",
+    "diffhtml-components": "^1.0.0-beta.9",
     "mocha": "^6.1.4"
+  },
+  "peerDependencies": {
+    "diffhtml": "^1.0.0-beta.10"
   },
   "keywords": [
     "diffhtml",

--- a/packages/diffhtml-render-to-string/package.json
+++ b/packages/diffhtml-render-to-string/package.json
@@ -15,6 +15,9 @@
   "peerDependencies": {
     "diffhtml": "^1.0.0-beta.10"
   },
+  "dependencies": {
+    "quick-dom-node": "1.0.0"
+  },
   "keywords": [
     "diffhtml",
     "server side rendering"

--- a/packages/diffhtml-render-to-string/test/index.js
+++ b/packages/diffhtml-render-to-string/test/index.js
@@ -1,7 +1,7 @@
 const { equal, throws } = require('assert');
 const { html } = require('diffhtml');
 const { Component } = require('diffhtml-components');
-const renderToString = require('../');
+const { renderToString } = require('../');
 
 describe('renderToString', function() {
   it('can render simple div string', () => {

--- a/packages/diffhtml-render-to-string/test/index.js
+++ b/packages/diffhtml-render-to-string/test/index.js
@@ -1,9 +1,37 @@
-const { equal } = require('assert');
+const { equal, throws } = require('assert');
 const { html } = require('diffhtml');
-const Component = require('diffhtml-components/dist/component');
+const { Component } = require('diffhtml-components');
 const renderToString = require('../');
 
 describe('renderToString', function() {
+  it('can render simple div string', () => {
+    const actual = renderToString('<div>Hello world</div>');
+    const expected = `<div>Hello world</div>`;
+
+    equal(actual, expected);
+  });
+
+  it('can render pure text, no wrapper element', () => {
+    const actual = renderToString('Hello world');
+    const expected = `Hello world`;
+
+    equal(actual, expected);
+  });
+
+  it('can support strict html parsing, throwing on error', () => {
+    throws(() => {
+      const actual = renderToString('<p>Hello world', { strict: true });
+    }, {
+      name: 'Error',
+      message: `
+
+<p>Hello world
+  ^
+    Possibly invalid markup. <p> is not a self closing tag.
+            `
+    });
+  });
+
   it('can render simple vTree', () => {
     const actual = renderToString(html`<div>Hello world</div>`);
     const expected = `<div>Hello world</div>`;
@@ -68,8 +96,8 @@ describe('renderToString', function() {
     equal(actual, expected);
   });
 
-  it('can render vanilla components with props', () => {
-    class Component {
+  it('can render components with props', () => {
+    class MyComponent extends Component {
       render({ message }) {
         return html`
           <p>${message}</p>
@@ -79,7 +107,29 @@ describe('renderToString', function() {
 
     const actual = renderToString(html`
       <div>
-        <${Component} message="Hello world" />
+        <${MyComponent} message="Hello world" />
+      </div>
+    `);
+
+    const expected = `<div>
+        <p>Hello world</p>
+      </div>`;
+
+    equal(actual, expected);
+  });
+
+  it('can render components with dynamic props', () => {
+    class MyComponent extends Component {
+      render({ display }) {
+        return html`
+          <p>${display.message}</p>
+        `;
+      }
+    }
+
+    const actual = renderToString(html`
+      <div>
+        <${MyComponent} display=${{ message: 'Hello world' }} />
       </div>
     `);
 

--- a/packages/diffhtml-render-to-string/test/index.js
+++ b/packages/diffhtml-render-to-string/test/index.js
@@ -1,5 +1,6 @@
 const { equal } = require('assert');
 const { html } = require('diffhtml');
+const Component = require('diffhtml-components/dist/component');
 const renderToString = require('../');
 
 describe('renderToString', function() {
@@ -46,7 +47,7 @@ describe('renderToString', function() {
   });
 
   it('can render components', () => {
-    class Component {
+    class MyComponent extends Component {
       render() {
         return html`
           <p>Hello world</p>
@@ -56,7 +57,7 @@ describe('renderToString', function() {
 
     const actual = renderToString(html`
       <div>
-        <${Component}  />
+        <${MyComponent}  />
       </div>
     `);
 

--- a/packages/diffhtml-website/build/generate.js
+++ b/packages/diffhtml-website/build/generate.js
@@ -1,7 +1,7 @@
 const { readFileSync, writeFileSync, existsSync } = require('fs');
 const { join } = require('path');
 const { html } = require('diffhtml');
-const renderToString = require('diffhtml-render-to-string');
+const { renderToString } = require('diffhtml-render-to-string');
 const marked = require('marked');
 const flattenPages = require('./util/flatten-pages');
 const { keys } = Object;

--- a/packages/diffhtml/lib/node/create.js
+++ b/packages/diffhtml/lib/node/create.js
@@ -3,6 +3,8 @@ import process from '../util/process';
 
 const { CreateNodeHookCache } = MiddlewareCache;
 const namespace = 'http://www.w3.org/2000/svg';
+const g = typeof global === 'object' ? global : window;
+const document = g.document || null;
 
 /**
  * Takes in a Virtual Tree Element (VTree) and creates a DOM Node from it.


### PR DESCRIPTION
I've wanted to update this module for a long time and finally got some inspiration to complete it. Before render-to-string was a hack that didn't support middleware (such as components) and instead tried to support the minimal amount of features possible.

Now it's a GIANT hack, but leverages all public APIs to support middleware and more! I refactored the tests to pull components from diffhtml-components to show a proof-of-concept.

I will continue adding tests in here so that behavior is understood.