### PR TITLE
Initial work on HTML linter based off htmlhint

### DIFF
--- a/packages/diffhtml-middleware-linter/.babelrc
+++ b/packages/diffhtml-middleware-linter/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["diffhtml-imports"]
+}

--- a/packages/diffhtml-middleware-linter/.gitignore
+++ b/packages/diffhtml-middleware-linter/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/packages/diffhtml-middleware-linter/README.md
+++ b/packages/diffhtml-middleware-linter/README.md
@@ -1,0 +1,21 @@
+# <±/> diffHTML Linter Middleware
+
+Stable Version: 1.0.0-beta.9
+
+Use to validate your markup for inconsistencies and bad practices using
+[HTMLHint](https://github.com/htmlhint/HTMLHint) rules.
+
+##### Installation
+
+``` sh
+npm install diffhtml-middleware-linter
+```
+
+##### Example
+
+``` javascript
+import { use } from 'diffhtml';
+import linter from 'diffhtml-middleware-linter';
+
+use(linter());
+```

--- a/packages/diffhtml-middleware-linter/index.js
+++ b/packages/diffhtml-middleware-linter/index.js
@@ -1,0 +1,245 @@
+const { assign, keys } = Object;
+
+const defaults = {
+  "tagname-lowercase": true,
+  "attr-lowercase": true,
+  "attr-value-double-quotes": true,       // requires parser change
+  "attr-value-not-empty": false,
+  "attr-no-duplication": true,            // requires parser change
+  "doctype-first": true,                  // requires parser change
+  "tag-pair": true,                       // requires parser change
+  "empty-tag-not-self-closed": true,      // requires parser change
+  "spec-char-escape": true,               // requires parser change
+  "id-unique": true,
+  "src-not-empty": true,
+  "title-require": true,
+  "alt-require": true,
+  "doctype-html5": true,                  // requires parser change
+  "id-class-value": "dash",
+  "style-disabled": false,
+  "inline-style-disabled": false,
+  "inline-script-disabled": false,
+  "space-tab-mixed-disabled": "space",    // requires parser change
+  "id-class-ad-disabled": false,          // tbd
+  "href-abs-or-rel": false,               // tbd
+  "attr-unsafe-chars": true,
+  "head-script-disabled": true,
+};
+
+const unsafeRegexp = /[\u0000-\u0009\u000b\u000c\u000e-\u001f\u007f-\u009f\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/;
+
+const srcTagNames = [
+  'img',
+  'video',
+  'script',
+  'link',
+  'embed',
+  'bgsound',
+  'iframe',
+  'object',
+];
+
+const state = {
+  ids: new Set(),
+  errors: [],
+  warnings: [],
+};
+
+const linter = ({ rules, renderErrors }) => {
+  rules = assign({}, defaults, rules);
+
+  return assign(function linterTask(transaction) {
+    console.info('Linting started with rules %o', rules);
+
+    return () => {
+      if (renderErrors && state.errors.length) {
+        transaction.domNode.innerHTML += `
+          <div style="background: #FAF7E8; border-top: 2px solid #FF0000; padding-bottom: 20px">
+            <h1>Validation errors</h1>
+            <h2 style="background:#FFB400;color:#FFF">Warnings</h2>
+            <ul>${state.warnings.map(err => `<li style="color:#FFB400">
+              <strong>${err}</strong>
+            </li>`).join('\n')}</ul>
+            <h2 style="background:#FF3D00;color:#FFF">Errors</h2>
+            <ul>${state.errors.map(err => `<li style="color:#FF3D00">
+              <strong>${err}</strong>
+            </li>`).join('\n')}</ul>
+          </div>
+        `;
+        //innerHTML(transaction.domNode, renderError({
+        //  errors: state.errors,
+        //  toString() {
+        //    return state.errors.join('\n');
+        //  }
+        //}));
+      }
+
+      state.ids.clear();
+
+      console.info('Linting completed');
+    };
+  }, {
+    createNodeHook(vTree) {
+      const { rawNodeName, nodeName, childNodes, attributes } = vTree;
+
+      if (nodeName === 'head') {
+        let hasTitle = false;
+        let hasScript = false;
+
+        childNodes.forEach(({ nodeName }) => {
+          if (nodeName === 'title') {
+            hasTitle = true;
+          }
+
+          if (nodeName === 'script') {
+            hasScript = true;
+          }
+        });
+
+        // head-script-disabled
+        if (rules['head-script-disabled'] && hasScript) {
+          const msg = `[title-require] head element must contain title`;
+          state.warnings.push(msg);
+          console.warn(msg);
+        }
+
+        // title-require
+        if (rules['title-require'] && !hasTitle) {
+          const msg = `[title-require] head element must contain title`;
+          state.errors.push(msg);
+          console.error(msg);
+        }
+      }
+
+      // alt-require
+      if (rules['alt-require'] && nodeName === 'img' && !attributes.alt) {
+        const msg = '[alt-require] img tag must have an alt present';
+        state.warnings.push(msg);
+        console.warn(msg);
+      }
+
+      // style-disabled
+      if (nodeName === 'style') {
+        console.warn(`[style-disabled] use of style tag is disabled`);
+      }
+
+      keys(attributes).forEach(key => {
+        const lowerKey = key.toLowerCase();
+        const value = attributes[key];
+
+        const absOrRel = rules['href-abs-or-rel'];
+
+        // href-abs-or-rel
+        if (absOrRel && lowerKey === 'href') {
+          const msg = `[href-abs-or-rel] '${value}' must be ${absOrRel}`;
+          state.warnings.push(msg);
+          console.warn(msg);
+        }
+
+        // attr-unsafe-chars
+        if (rules['attr-unsafe-chars'] && String(value).match(unsafeRegexp)) {
+          const msg = `[attr-unsafe-chars] '${value}' contains unsafe characters`;
+          state.warnings.push(msg);
+          console.warn(msg);
+        }
+
+        // inline-style-disabled
+        if (rules['inline-style-disabled'] && lowerKey === 'style') {
+          const msg = `[inline-style-disabled] cannot use inline styles`;
+          state.warnings.push(msg);
+          console.warn(msg);
+        }
+
+        // inline-script-disabled
+        if (rules['inline-script-disabled'] && (
+          value.includes('javascript:') ||
+          value.includes('(') ||
+          value.includes('[') ||
+          value.includes('{')
+        )) {
+          const msg = `[inline-script-disabled] detected inline script execution`;
+          state.warnings.push(msg);
+          console.warn(msg);
+        }
+
+        const idClassValue = rules['id-class-value'];
+        const validFormats = ['underline', 'dash', 'hump'];
+
+        // id-class-value
+        if (idClassValue && (lowerKey === 'id' || lowerKey === 'class')) {
+          if (!validFormats.includes(idClassValue)) {
+            throw new Error('Invalid configuration format for [id-class-value]');
+          }
+
+          let failed = null;
+
+          if (idClassValue === 'underline') {
+            failed = String(value).match(/^[a-z\d]+(_[a-z\d]+)*$/);
+          }
+          else if (idClassValue === 'dash') {
+            failed = String(value).match(/^[a-z\d]+(-[a-z\d]+)*$/);
+          }
+          else if (idClassValue === 'hump') {
+            failed = String(value).match(/^[a-z][a-zA-Z\d]*([A-Z][a-zA-Z\d]*)*$/);
+          }
+
+          if (failed) {
+            const msg = `[id-class-value] '${value}' must be in ${idClassValue} format`;
+            state.warnings.push(msg);
+            console.warn(msg);
+          }
+        }
+
+        // id-unique
+        if (rules['id-unique'] === true && lowerKey === 'id' && state.ids.has(attributes[key])) {
+          const msg = `[id-unique] encountered duplicate '${attributes[key]}'`;
+          state.errors.push(msg);
+          console.error(msg);
+        }
+
+        // attr-lowercase
+        if (rules['attr-lowercase'] === true || rules['attr-lowercase'].indexOf(nodeName) === -1) {
+          if (lowerKey !== key) {
+            const msg = `[attr-lowercase] attributes must be lowercase, encountered ${key}`;
+            state.warnings.push(msg);
+            console.warn(msg);
+          }
+        }
+
+        // attr-value-not-empty
+        if (
+          rules['attr-value-not-empty'] && (
+            attributes[key] === undefined ||
+            attributes[key] === null ||
+            attributes[key] === ''
+          )
+        ) {
+          const msg = `[attr-value-not-empty] ${rawNodeName} ${key} cannot be empty`;
+          state.warnings.push(msg);
+          console.warn(msg);
+        }
+
+        // Track id values.
+        if (lowerKey === 'id') {
+          state.ids.add(attributes[key]);
+        }
+      });
+
+      // tagname-lowercase
+      if (rules['tagname-lowercase'] && rawNodeName.toUpperCase() === rawNodeName) {
+        const msg = `[tagname-lowercase] ${rawNodeName} must be lowercase`;
+        state.errors.push(msg);
+        console.error(msg);
+      }
+
+      // src-not-empty
+      if (rules['src-not-empty'] && srcTagNames.includes(nodeName) && !attributes.src) {
+        const msg = `[src-not-empty] ${nodeName} must have a valid src attribute`;
+        state.errors.push(msg);
+        console.error(msg);
+      }
+    },
+  });
+};
+
+export default (opts = {}) => linter(opts);

--- a/packages/diffhtml-middleware-linter/package.json
+++ b/packages/diffhtml-middleware-linter/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "diffhtml-middleware-linter",
+  "version": "1.0.0",
+  "description": "Lints HTML parsed by diffHTML",
+  "main": "dist/cjs/index",
+  "module": "dist/es/index",
+  "jsnext:main": "dist/es/index",
+  "esnext:main": "dist/es/index",
+  "scripts": {
+    "prepublishOnly": "npm run min",
+    "clean": "rm -rf dist/* && mkdir -p dist",
+    "min": "npm run build && npm run build-min",
+    "build": "npm run clean && npm run build-umd && npm run build-cjs && npm run build-esm",
+    "build-cjs": "NODE_ENV=cjs babel index.js -d dist/cjs",
+    "build-esm": "NODE_ENV=esm babel index.js -d dist/es",
+    "build-umd": "NODE_ENV=umd rollup -c rollup.config.js",
+    "build-min": "NODE_ENV=min rollup -c rollup.config.js && uglifyjs dist/linter.min.js -o dist/linter.min.js -m -c",
+    "watch": "NODE_ENV=umd rollup -c rollup.config.js -w"
+  },
+  "keywords": [
+    "diffhtml",
+    "linter",
+    "middleware"
+  ],
+  "author": "Tim Branyen (@tbranyen)",
+  "license": "MIT",
+  "devDependencies": {
+    "@babel/cli": "^7.4.4",
+    "@babel/core": "^7.4.4",
+    "babel-preset-diffhtml-imports": "^1.0.0-beta.9",
+    "diffhtml": "^1.0.0-beta.10",
+    "rollup": "^1.11.3",
+    "rollup-plugin-babel": "^4.3.2",
+    "rollup-plugin-node-resolve": "^4.2.3",
+    "rollup-plugin-replace": "^2.2.0",
+    "rollup-plugin-visualizer": "^1.1.1",
+    "rollup-watch": "^4.3.1",
+    "uglify-js": "^3.5.11"
+  },
+  "peerDependencies": {
+    "diffhtml": "^1.0.0-beta.10"
+  }
+}

--- a/packages/diffhtml-middleware-linter/rollup.config.js
+++ b/packages/diffhtml-middleware-linter/rollup.config.js
@@ -1,0 +1,37 @@
+import babel from 'rollup-plugin-babel';
+import nodeResolve from 'rollup-plugin-node-resolve';
+import replace from 'rollup-plugin-replace';
+import Visualizer from 'rollup-plugin-visualizer';
+
+const entries = {
+  min: 'index.js',
+  umd: 'index.js',
+};
+
+const dests = {
+  min: 'dist/linter.min.js',
+  umd: 'dist/linter.js',
+}
+
+const { NODE_ENV = 'umd' } = process.env;
+
+export const input = entries[NODE_ENV];
+export const context = 'this';
+
+export const globals = { diffhtml: 'diff' };
+export const external = ['diffhtml'];
+
+export const output = [{
+  file: dests[NODE_ENV],
+  format: 'umd',
+  exports: 'default',
+  name: 'linter',
+  sourcemap: false,
+}];
+
+export const plugins = [
+  NODE_ENV === 'min' && replace({ 'process.env.NODE_ENV': JSON.stringify('production') }),
+  babel(),
+  nodeResolve({ jsnext: true }),
+  NODE_ENV === 'umd' && Visualizer({ filename: './dist/build-size.html' }),
+];

--- a/packages/diffhtml-middleware-linter/test.html
+++ b/packages/diffhtml-middleware-linter/test.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+
+  <title>Test</title>
+</head>
+<body>
+  <script src="https://diffhtml.org/master/diffhtml/dist/diffhtml.js"></script>
+  <script src="dist/linter.js"></script>
+  <script>
+    diff.use(linter({
+      rules: {
+        'attr-value-not-empty': true,
+        'inline-style-disabled': true,
+        'inline-script-disabled': true,
+      },
+
+      renderErrors: true,
+    }));
+
+    setInterval(() => {
+      diff.innerHTML(document.body, `
+        <!doctype html>
+        <H1>Hello world</H1>
+        <span ID="true"></span>
+        <video src="" />
+        <img disabled="" id="true" />
+
+        <head style="font-weight:bold">
+          <script><\/script>
+          <tittle onclick="test()"></tittle>
+        </head>
+      `);
+    }, 1000);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Allows validating HTML input using HTMLHint (https://github.com/htmlhint/HTMLHint) rules.

Usage:

```js
import { use, innerHTML } from 'diffhtml';
import linter from 'diffhtml-middleware-linter';

// Default rules
use(linter());

innerHTML(document.body, `
  <a HREF="failure" />
`);
```