### PR TITLE
Resolve namespace issues when creating SVG element

### DIFF
--- a/packages/diffhtml/lib/node/patch.js
+++ b/packages/diffhtml/lib/node/patch.js
@@ -148,7 +148,7 @@ const changeNodeValue = (domNode, nodeValue) => {
  */
 export default function patchNode(patches, state = {}) {
   const promises = [];
-  const { isSVG, ownerDocument } = state;
+  const { ownerDocument, svgElements = new Set() } = state;
   const { length } = patches;
 
   let i = 0;
@@ -168,6 +168,7 @@ export default function patchNode(patches, state = {}) {
 
         i += 4;
 
+        const isSVG = svgElements.has(vTree);
         const domNode = /** @type {HTMLElement} */ (
           createNode(vTree, ownerDocument, isSVG)
         );
@@ -197,6 +198,7 @@ export default function patchNode(patches, state = {}) {
 
         i += 3;
 
+        const isSVG = svgElements.has(vTree);
         const domNode = /** @type {HTMLElement} */ (
           createNode(vTree, ownerDocument, isSVG)
         );
@@ -224,6 +226,7 @@ export default function patchNode(patches, state = {}) {
         const vTree = patches[i + 1];
         const nodeValue = patches[i + 2];
         const oldValue = patches[i + 3];
+        const isSVG = svgElements.has(vTree);
 
         i += 4;
 
@@ -269,6 +272,8 @@ export default function patchNode(patches, state = {}) {
           break;
         }
 
+        const isSVG = svgElements.has(newTree);
+
         protectVTree(newTree);
 
         const refNode = refTree && /** @type {HTMLElement} */ (
@@ -293,6 +298,8 @@ export default function patchNode(patches, state = {}) {
         const oldTree = patches[i + 2];
 
         i += 3;
+
+        const isSVG = svgElements.has(newTree);
 
         const oldDomNode = /** @type {HTMLElement} */ (NodeCache.get(oldTree));
         const newDomNode = /** @type {HTMLElement} */ (

--- a/packages/diffhtml/lib/tasks/patch-node.js
+++ b/packages/diffhtml/lib/tasks/patch-node.js
@@ -10,11 +10,9 @@ import Transaction from '../transaction';
 export default function patch(transaction) {
   const { domNode, state, state: { measure }, patches } = transaction;
   /** @type {HTMLElement | DocumentFragment} */
-  const { nodeName, namespaceURI, ownerDocument } = (domNode);
+  const { ownerDocument } = (domNode);
   const promises = transaction.promises || [];
-  const namespaceURIString = namespaceURI || '';
 
-  state.isSVG = nodeName.toLowerCase() === 'svg' || namespaceURIString.includes('svg');
   state.ownerDocument = ownerDocument || document;
 
   measure('patch node');

--- a/packages/diffhtml/lib/tasks/sync-trees.js
+++ b/packages/diffhtml/lib/tasks/sync-trees.js
@@ -6,7 +6,7 @@ import process from '../util/process';
 import Transaction from '../transaction';
 
 export default function syncTrees(/** @type {Transaction} */ transaction) {
-  const { state: { measure }, oldTree, newTree, domNode } = transaction;
+  const { state, state: { measure }, oldTree, newTree, domNode } = transaction;
 
   measure('sync trees');
 
@@ -45,15 +45,20 @@ export default function syncTrees(/** @type {Transaction} */ transaction) {
     ];
 
     // Clean up the existing old tree, and mount the new tree.
-    transaction.oldTree = transaction.state.oldTree = newTree;
+    transaction.oldTree = state.oldTree = newTree;
 
     // Update the StateCache since we are changing the top level element.
     StateCache.delete(domNode);
-    StateCache.set(createNode(newTree), transaction.state);
+    StateCache.set(createNode(newTree), state);
   }
   // Synchronize the top level elements.
   else {
-    transaction.patches = syncTree(oldTree || null, newTree || null, []);
+    transaction.patches = syncTree(
+      oldTree || null,
+      newTree || null,
+      [],
+      state,
+    );
   }
 
   measure('sync trees');

--- a/packages/diffhtml/lib/transaction.js
+++ b/packages/diffhtml/lib/transaction.js
@@ -115,6 +115,7 @@ export default class Transaction {
 
     this.state = StateCache.get(domNode) || {
       measure: makeMeasure(domNode, input),
+      svgElements: new Set(),
     };
 
     if (options.tasks && options.tasks.length) {
@@ -189,6 +190,9 @@ export default class Transaction {
     // Cache the markup and text for the DOM node to allow for short-circuiting
     // future render transactions.
     state.previousMarkup = 'outerHTML' in /** @type {any} */ (domNode) ? domNode.outerHTML : '';
+
+    // Clean up SVG element list.
+    state.svgElements.clear();
 
     // Rendering is complete.
     state.isRendering = false;

--- a/packages/diffhtml/test/integration/svg.js
+++ b/packages/diffhtml/test/integration/svg.js
@@ -19,7 +19,40 @@ describe('Integration: SVG', function() {
     it('can create SVG elements', function() {
       diff.innerHTML(this.fixture, '<g id="test"></g>');
 
-      assert.equal(this.fixture.firstChild.namespaceURI, this.namespace);
+      assert.equal(this.fixture.querySelector('g').namespaceURI, this.namespace);
+    });
+
+    it('can insert complete SVG documents', function() {
+      const container = document.createElement('div');
+
+      diff.innerHTML(container, '<svg><g id="test"></g></svg>');
+
+      assert.equal(container.querySelector('g').namespaceURI, this.namespace);
+
+      diff.release(container);
+    });
+
+    it('can diff complete SVG documents', function() {
+      const container = document.createElement('div');
+
+      diff.innerHTML(container, '<svg><g id="test"></g></svg>');
+      assert.equal(container.querySelector('g').namespaceURI, this.namespace);
+
+      diff.innerHTML(container, '<svg><rect id="test2" /></svg>');
+      assert.equal(container.querySelector('rect').namespaceURI, this.namespace);
+
+      diff.release(container);
+    });
+
+    it('can replace element with complete SVG document', function() {
+      const container = document.createElement('div');
+
+      diff.innerHTML(container, '<div></div>>');
+      diff.innerHTML(container, '<svg><rect id="test2" /></svg>');
+      assert.equal(container.querySelector('svg').namespaceURI, this.namespace);
+      assert.equal(container.querySelector('rect').namespaceURI, this.namespace);
+
+      diff.release(container);
     });
   });
 });


### PR DESCRIPTION
Prior to this commit, SVG would only work if rendered directly from the
top, like: `diff.innerHTML(document.body, '<svg></svg>');` and not when
diffing or creating within an existing document.

This corrects the behavior by determining the correct type during
synchronization, applying this VTree reference to an `svgElements` set,
and then referencing this when creating elements in the patch phase.

This should not incur any memory overhead or significant processing and
keeps our VTree shape lean, and filesize low by not including a list of
all SVG elements.

Fixes GH #185