### PR TITLE
Greatly improve handling of untracked elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ render in a web browser or Node.
 - Powerful **middleware** extends diffHTML with additional features.
 - **Web** and **React**-compatible stateful components.
 - View and debug your code using the **Chrome DevTools extension**.
-- A **lite** build which has a smaller size, meant for optimizing production code
+- A **lite** build which has a smaller size, meant for optimizing production code.
 
 ## Packages
 

--- a/packages/diffhtml-components/lib/shared/middleware.js
+++ b/packages/diffhtml-components/lib/shared/middleware.js
@@ -66,6 +66,10 @@ const syncTreeHook = (oldTree, newTree) => {
     return render(oldTree, newTree) || oldTree;
   }
 
+  if (!newTree.childNodes) {
+    return oldTree;
+  }
+
   // Loop through childNodes seeking out components to render.
   for (let i = 0; i < newTree.childNodes.length; i++) {
     const newChildTree = newTree.childNodes[i];
@@ -86,6 +90,9 @@ const syncTreeHook = (oldTree, newTree) => {
           if (typeof renderTree.rawNodeName === 'function') {
             i = i - 1;
           }
+          // Replace the fragment with the rendered elements. Maybe in the
+          // future this could remain a fragment and seamlessly patch into the
+          // DOM.
           else {
             newTree.childNodes.splice(i, 1, ...renderTree.childNodes);
           }
@@ -98,7 +105,7 @@ const syncTreeHook = (oldTree, newTree) => {
   }
 };
 
-export default Constructor => assign(
+export default () => assign(
   transaction => transaction.onceEnded(onceEnded),
   {
     displayName: 'componentTask',

--- a/packages/diffhtml-website/pages/api.md
+++ b/packages/diffhtml-website/pages/api.md
@@ -523,7 +523,9 @@ additional cleanup here.
 ### <a name="sync-tree-hook-cache" href="#sync-tree-hook-cache">SyncTreeHookCache</a>
 
 A JavaScript Set object that contains functions that trigger whenever Virtual
-Trees are compared.
+Trees are compared. You can influence how the Virtual DOM synchronizes changes,
+by changing attributes JIT, telling diffHTML to ignore certain nodes, or tell
+diffHTML to not apply any changes to a given node.
 
 ### <a name="node-cache" href="#node-cache">NodeCache</a>
 

--- a/packages/diffhtml/lib/tree/sync.js
+++ b/packages/diffhtml/lib/tree/sync.js
@@ -2,42 +2,41 @@ import { SyncTreeHookCache } from '../util/caches';
 import process from '../util/process';
 import { PATCH_TYPE, VTree, EMPTY, TransactionState } from '../util/types';
 
+const { max } = Math;
 const keyNames = ['old', 'new'];
 const textName = '#text';
 
-// Compares how the new state should look to the old state and mutates it,
-// while recording the changes along the way.
 /**
+ * Compares how the new state should look to the old state and mutates it,
+ * while recording the changes along the way.
  *
  * @param {Partial<VTree> | null} oldTree
- * @param {Partial<VTree> | null} newTree
+ * @param {Partial<VTree> | null=} newTree
  * @param {any[]} patches
  * @param {Partial<TransactionState>} state
+ * @param {boolean} attributesOnly
+ *
+ * @return {any[] | false}
  */
-export default function syncTree(oldTree, newTree, patches = [], state = {}) {
+export default function syncTree(
+  oldTree,
+  newTree,
+  patches = [],
+  state = {},
+  attributesOnly = false,
+) {
   if (!oldTree) oldTree = /** @type {VTree} */ (EMPTY.OBJ);
   if (!newTree) newTree = /** @type {VTree} */ (EMPTY.OBJ);
 
   const { svgElements = new Set() } = state;
   const oldNodeName = oldTree.nodeName;
-  const isFragment = newTree.nodeType === 11 || oldTree.nodeType === 11;
-  const isEmpty = oldTree === EMPTY.OBJ;
+  const newNodeName = newTree.nodeName;
+  const isEmpty = oldTree === EMPTY.OBJ || attributesOnly;
 
   // Check for SVG in parent.
-  const isSVG = newTree.nodeName === 'svg' || svgElements.has(/** @type {VTree} */ (newTree));
-
-  if (process.env.NODE_ENV !== 'production') {
-    if (newTree === EMPTY.OBJ) {
-      throw new Error('Missing new Virtual Tree to sync changes from');
-    }
-
-    // FIXME: Causes issues w/ React, we need to normalize at a higher level.
-    if (!isEmpty && oldNodeName !== newTree.nodeName && !isFragment) {
-      throw new Error(
-        `Sync failure, cannot compare ${newTree.nodeName} with ${oldNodeName}`
-      );
-    }
-  }
+  const isSVG = newNodeName === 'svg' || svgElements.has(
+    /** @type {VTree} */ (newTree)
+  );
 
   let shortCircuit = null;
 
@@ -47,7 +46,7 @@ export default function syncTree(oldTree, newTree, patches = [], state = {}) {
   // DOM from changes or diffs. Another useful way to use these hooks are to
   // take the new tree, and convert it into something else. This is how
   // components are implemented.
-  SyncTreeHookCache.forEach(fn => {
+  oldTree !== EMPTY.OBJ && SyncTreeHookCache.forEach(fn => {
     // Call the user provided middleware function for a single root node. Allow
     // the consumer to specify a return value of a different VTree (useful for
     // components).
@@ -56,7 +55,12 @@ export default function syncTree(oldTree, newTree, patches = [], state = {}) {
     // If the value returned matches the original element, then short circuit
     // and do not dig further.
     if (entry && entry === oldTree) {
-      shortCircuit = true;
+      shortCircuit = patches;
+    }
+    // Allow skipping an element for diffing. It will be preserved and kept
+    // in the DOM.
+    else if (entry === false) {
+      shortCircuit = false;
     }
     // If the user has returned a value, treat it as the new tree.
     else if (entry) {
@@ -64,45 +68,16 @@ export default function syncTree(oldTree, newTree, patches = [], state = {}) {
     }
   });
 
-  if (shortCircuit) {
-    return patches;
+  if (shortCircuit !== null || !newTree) {
+    return shortCircuit;
   }
-
-  /** @type {any} */
-  const keysLookup = { old: new Map(), new: new Map() };
-
-  // Reduce duplicate logic by condensing old and new operations in a loop.
-  for (let i = 0; i < keyNames.length; i++) {
-    const keyName = keyNames[i];
-    const map = keysLookup[keyName];
-    const vTree = arguments[i];
-    const nodes = vTree && vTree.childNodes;
-
-    if (nodes && nodes.length) {
-      for (let i = 0; i < nodes.length; i++) {
-        const vTree = nodes[i];
-
-        if (vTree.key) {
-          if (process.env.NODE_ENV !== 'production') {
-            if (map.has(vTree.key)) {
-              throw new Error(`Key: ${vTree.key} cannot be duplicated`);
-            }
-          }
-
-          map.set(vTree.key, vTree);
-        }
-      }
-    }
-  }
-
-  const isElement = newTree.nodeType === 1;
 
   // Text nodes are low level and frequently change, so this path is accounted
   // for first.
-  if (newTree.nodeName === textName) {
-    if (oldTree.nodeName === textName && oldTree.nodeValue !== newTree.nodeValue) {
-    // If both VTrees are text nodes and the values are different, change the
-    // `Element#nodeValue`.
+  if (newNodeName === textName) {
+    if (oldNodeName === textName && oldTree.nodeValue !== newTree.nodeValue) {
+      // If both VTrees are text nodes and the values are different, change the
+      // `Element#nodeValue`.
       patches.push(
         PATCH_TYPE.NODE_VALUE,
         oldTree,
@@ -126,6 +101,9 @@ export default function syncTree(oldTree, newTree, patches = [], state = {}) {
       return patches;
     }
   }
+
+  const newChildNodes = newTree.childNodes || [];
+  const isElement = newTree.nodeType === 1;
 
   // Seek out attribute changes first, but only from element Nodes.
   if (isElement) {
@@ -171,34 +149,74 @@ export default function syncTree(oldTree, newTree, patches = [], state = {}) {
     }
   }
 
-  const newChildNodes = newTree.childNodes || [];
-
   // Scan all childNodes for attribute changes.
-  if (isEmpty) {
+  if (attributesOnly) {
     // Do a single pass over the new child nodes.
     for (let i = 0; i < newChildNodes.length; i++) {
       if (isSVG) {
         svgElements.add(newChildNodes[i]);
       }
 
-      syncTree(null, newChildNodes[i], patches, state);
+      syncTree(null, newChildNodes[i], patches, state, true);
     }
 
     return patches;
   }
 
+  /** @type {any} */
+  const keysLookup = { old: new Map(), new: new Map() };
+
+  // Reduce duplicate logic by condensing old and new operations in a loop.
+  for (let i = 0; i < keyNames.length; i++) {
+    const keyName = keyNames[i];
+    const map = keysLookup[keyName];
+    const vTree = arguments[i];
+    const nodes = vTree && vTree.childNodes;
+
+    if (nodes && nodes.length) {
+      for (let i = 0; i < nodes.length; i++) {
+        const vTree = nodes[i];
+
+        if (vTree.key) {
+          if (process.env.NODE_ENV !== 'production') {
+            if (map.has(vTree.key)) {
+              throw new Error(`Key: ${vTree.key} cannot be duplicated`);
+            }
+          }
+
+          map.set(vTree.key, vTree);
+        }
+      }
+    }
+  }
+
   /** @type {VTree[]} */
   const oldChildNodes = (oldTree.childNodes);
 
-  // Do a single pass over the new child nodes.
-  for (let i = 0; i < newChildNodes.length; i++) {
+  // Used when skipping over nodes during syncTreeHook.
+  let maxLength = max(newChildNodes.length, oldChildNodes.length);
+
+  // Always perform a full diff based on the largest set of nodes. The end user
+  // may want to do something with any of them, so while it may be more
+  // performant to only loop over the new nodes, we loop over all instead.
+  for (let i = 0; i < maxLength; i++) {
     const oldChildNode = oldChildNodes && oldChildNodes[i];
     const newChildNode = newChildNodes[i];
-    const newKey = newChildNode.key;
 
     // Check for SVG in child as well.
-    if (isSVG || newChildNode.nodeName === 'svg') {
+    if (isSVG || (newChildNode && newChildNode.nodeName === 'svg')) {
       svgElements.add(newChildNode);
+    }
+
+    // If there is no new child node, we will skip this comparison. If the old
+    // node is something we want to preserve, we can migrate it to the new
+    // nodes.
+    if (!newChildNode) {
+      if (syncTree(oldChildNode, null, patches, state, true) === false) {
+        newChildNodes.splice(i, 0, oldChildNode);
+      }
+
+      continue;
     }
 
     // If there is no old element to compare to, this is a simple addition.
@@ -206,7 +224,7 @@ export default function syncTree(oldTree, newTree, patches = [], state = {}) {
       oldChildNodes.push(newChildNode);
 
       // Crawl this Node for any changes to apply.
-      syncTree(null, newChildNode, patches, state);
+      syncTree(null, newChildNode, patches, state, true);
 
       patches.push(
         PATCH_TYPE.INSERT_BEFORE,
@@ -218,6 +236,7 @@ export default function syncTree(oldTree, newTree, patches = [], state = {}) {
       continue;
     }
 
+    const newKey = newChildNode.key;
     const oldKey = oldChildNode.key;
     const oldInNew = keysLookup.new.has(oldKey);
     const newInOld = keysLookup.old.has(newKey);
@@ -227,7 +246,7 @@ export default function syncTree(oldTree, newTree, patches = [], state = {}) {
       // Remove the old node instead of replacing.
       if (!oldInNew && !newInOld) {
         oldChildNodes.splice(oldChildNodes.indexOf(oldChildNode), 1, newChildNode);
-        syncTree(null, newChildNode, patches, state);
+        syncTree(null, newChildNode, patches, state, true);
 
         patches.push(PATCH_TYPE.REPLACE_CHILD, newChildNode, oldChildNode);
 
@@ -258,7 +277,7 @@ export default function syncTree(oldTree, newTree, patches = [], state = {}) {
         }
 
         // Crawl this Node for any changes to apply.
-        syncTree(null, optimalNewNode, patches, state);
+        syncTree(null, optimalNewNode, patches, state, true);
 
         patches.push(
           PATCH_TYPE.INSERT_BEFORE,
@@ -272,9 +291,18 @@ export default function syncTree(oldTree, newTree, patches = [], state = {}) {
       }
     }
 
+    const sameType = oldChildNode.nodeName === newChildNode.nodeName;
+    const retVal = syncTree(oldChildNode, newChildNode, patches, state, !sameType);
+
+    if (retVal === false) {
+      newChildNodes.splice(i, 0, oldChildNode);
+      maxLength += 1;
+      continue;
+    }
+
     // If the element we're replacing is totally different from the previous
     // replace the entire element, don't bother investigating children.
-    if (oldChildNode.nodeName !== newChildNode.nodeName) {
+    if (!sameType) {
       oldChildNodes[i] = newChildNode;
 
       // This only works if VTrees are identical...
@@ -284,18 +312,8 @@ export default function syncTree(oldTree, newTree, patches = [], state = {}) {
         oldChildNodes.splice(lookupIndex, 1);
       }
 
-      syncTree(null, newChildNode, patches, state);
-
-      patches.push(
-        PATCH_TYPE.REPLACE_CHILD,
-        newChildNode,
-        oldChildNode,
-      );
-
-      continue;
+      patches.push(PATCH_TYPE.REPLACE_CHILD, newChildNode, oldChildNode);
     }
-
-    syncTree(oldChildNode, newChildNode, patches, state);
   }
 
   // We've reconciled new changes, so we can remove any old nodes and adjust

--- a/packages/diffhtml/lib/tree/sync.js
+++ b/packages/diffhtml/lib/tree/sync.js
@@ -46,7 +46,7 @@ export default function syncTree(
   // DOM from changes or diffs. Another useful way to use these hooks are to
   // take the new tree, and convert it into something else. This is how
   // components are implemented.
-  if (SyncTreeHookCache.size && oldTree !== EMPTY.OBJ) {
+  if (SyncTreeHookCache.size) {
     SyncTreeHookCache.forEach(fn => {
       // Call the user provided middleware function for a single root node.
       // Allow the consumer to specify a return value of a different VTree
@@ -105,10 +105,9 @@ export default function syncTree(
   }
 
   const newChildNodes = newTree.childNodes || [];
-  const isElement = newTree.nodeType === 1;
 
   // Seek out attribute changes first, but only from element Nodes.
-  if (isElement) {
+  if (newTree.nodeType === 1) {
     const oldAttributes = isEmpty ? EMPTY.OBJ : oldTree.attributes;
     const newAttributes = newTree.attributes;
 
@@ -155,10 +154,9 @@ export default function syncTree(
   if (attributesOnly) {
     // Do a single pass over the new child nodes.
     for (let i = 0; i < newChildNodes.length; i++) {
-      if (isSVG) {
-        svgElements.add(newChildNodes[i]);
-      }
-
+      // Ensure all SVG elements are tracked.
+      isSVG && svgElements.add(newChildNodes[i]);
+      //console.log('a', newChildNodes[i]);
       syncTree(null, newChildNodes[i], patches, state, true);
     }
 
@@ -307,7 +305,7 @@ export default function syncTree(
     if (!sameType) {
       oldChildNodes[i] = newChildNode;
 
-      // This only works if VTrees are identical...
+      // This only works if VTrees are identical.
       const lookupIndex = oldChildNodes.lastIndexOf(newChildNode);
 
       if (lookupIndex > i) {

--- a/packages/diffhtml/lib/tree/sync.js
+++ b/packages/diffhtml/lib/tree/sync.js
@@ -156,7 +156,6 @@ export default function syncTree(
     for (let i = 0; i < newChildNodes.length; i++) {
       // Ensure all SVG elements are tracked.
       isSVG && svgElements.add(newChildNodes[i]);
-      //console.log('a', newChildNodes[i]);
       syncTree(null, newChildNodes[i], patches, state, true);
     }
 

--- a/packages/diffhtml/lib/tree/sync.js
+++ b/packages/diffhtml/lib/tree/sync.js
@@ -16,7 +16,7 @@ const textName = '#text';
  * @param {Partial<TransactionState>} state
  * @param {boolean} attributesOnly
  *
- * @return {any[] | false}
+ * @return {any[] | false | null}
  */
 export default function syncTree(
   oldTree,

--- a/packages/diffhtml/lib/tree/sync.js
+++ b/packages/diffhtml/lib/tree/sync.js
@@ -46,27 +46,29 @@ export default function syncTree(
   // DOM from changes or diffs. Another useful way to use these hooks are to
   // take the new tree, and convert it into something else. This is how
   // components are implemented.
-  oldTree !== EMPTY.OBJ && SyncTreeHookCache.forEach(fn => {
-    // Call the user provided middleware function for a single root node. Allow
-    // the consumer to specify a return value of a different VTree (useful for
-    // components).
-    const entry = fn(oldTree, newTree);
+  if (SyncTreeHookCache.size && oldTree !== EMPTY.OBJ) {
+    SyncTreeHookCache.forEach(fn => {
+      // Call the user provided middleware function for a single root node.
+      // Allow the consumer to specify a return value of a different VTree
+      // (useful for components).
+      const entry = fn(oldTree, newTree);
 
-    // If the value returned matches the original element, then short circuit
-    // and do not dig further.
-    if (entry && entry === oldTree) {
-      shortCircuit = patches;
-    }
-    // Allow skipping an element for diffing. It will be preserved and kept
-    // in the DOM.
-    else if (entry === false) {
-      shortCircuit = false;
-    }
-    // If the user has returned a value, treat it as the new tree.
-    else if (entry) {
-      newTree = entry;
-    }
-  });
+      // If the value returned matches the original element, then short circuit
+      // and do not dig further.
+      if (entry && entry === oldTree) {
+        shortCircuit = patches;
+      }
+      // Allow skipping an element for diffing. It will be preserved and kept
+      // in the DOM.
+      else if (entry === false) {
+        shortCircuit = false;
+      }
+      // If the user has returned a value, treat it as the new tree.
+      else if (entry) {
+        newTree = entry;
+      }
+    });
+  }
 
   if (shortCircuit !== null || !newTree) {
     return shortCircuit;

--- a/packages/diffhtml/test/integration/inner.js
+++ b/packages/diffhtml/test/integration/inner.js
@@ -89,7 +89,7 @@ describe('Integration: innerHTML', function() {
 
     document.body.removeChild(this.fixture);
 
-    diff.innerHTML(this.fixture, ``);
+    diff.innerHTML(this.fixture, '');
 
     assert.equal(this.fixture.innerHTML, '');
   });

--- a/packages/diffhtml/test/tree.js
+++ b/packages/diffhtml/test/tree.js
@@ -635,34 +635,18 @@ describe('Tree', function() {
   });
 
   describe('sync', () => {
-    it('will error if missing a new tree to sync into', () => {
-      const oldTree = createTree('div');
-      const newTree = undefined;
-
-      throws(() => syncTree(oldTree, newTree), /Missing new Virtual Tree/);
-    });
-
-    it('will not throw custom error if in production', () => {
-      const oldTree = createTree('div');
-      const newTree = undefined;
-
-      process.env.NODE_ENV = 'production';
-
-      doesNotThrow(() => syncTree(oldTree, newTree), /Cannot read property 'length'/);
-    });
-
-    it('will throw an error if top level elements are different', () => {
+    it('will not throw an error if top level elements are different', () => {
       const oldTree = createTree('div');
       const newTree = createTree('h1');
 
-      throws(() => syncTree(oldTree, newTree), /cannot compare h1 with div/);
+      doesNotThrow(() => syncTree(oldTree, newTree));
     });
 
-    it('will throw an error if the new tree is not the same type', () => {
+    it('will not throw an error if the new tree is not the same type', () => {
       const oldTree = createTree('div');
       const newTree = createTree('span');
 
-      throws(() =>  syncTree(oldTree, newTree));
+      doesNotThrow(() =>  syncTree(oldTree, newTree));
     });
 
     it('will generate an empty patchset if there are no changes', () => {


### PR DESCRIPTION
This change improves synchronization to always account for all elements in either the old or new set. Before we only cared about the new set which short circuits a lot of logic. This comes at a negative when you have elements added by third parties and want to ensure that diffHTML can seamlessly render around them. This allows us to call the `SyncTreeHook` for every old node. This is beneficial in the case where you've added nodes without diffHTML (possibly by a third party) and would like a chance to tell diffHTML to ignore them.

To ignore diffing an element you can use the following new code pattern:

```js
import { innerHTML, use, Internals } from 'diffhtml';

use({
  syncTreeHook(oldTree) {
    // Inspect the VTree for attributes or nodeName and return false to tell
    // diffHTML to completely ignore and treat the node as not even there.
    if (oldTree.nodeName === 'div') {
      return false;
    }

    // You could also get the respective DOM node to do reference comparisons.
    const domNode = Internals.NodeCache.get(oldTree);

    if (ignoredNodes.includes(domNode)) {
      return false;
    }
  }
});
```

Closes GH-201.