### PR TITLE
Remove code from block elements, fixes GH-209

### DIFF
--- a/packages/diffhtml/lib/util/parse.js
+++ b/packages/diffhtml/lib/util/parse.js
@@ -26,7 +26,6 @@ const blockTextDefaults = [
   'script',
   'noscript',
   'style',
-  'code',
   'template',
 ];
 

--- a/packages/diffhtml/test/util.js
+++ b/packages/diffhtml/test/util.js
@@ -367,6 +367,14 @@ describe('Util', function() {
       equal(vTrees[0].childNodes[0].nodeName, 'code');
     });
 
+    it('will support nested elements within <code>', () => {
+      const vTrees = parse(`<code><pre></pre></code>`).childNodes;
+
+      equal(vTrees[0].nodeName, 'code');
+      equal(vTrees[0].childNodes.length, 1);
+      equal(vTrees[0].childNodes[0].nodeName, 'pre');
+    });
+
     it('will not support nested elements within <script>', () => {
       const vTrees = parse(`<script><pre></pre></script>`).childNodes;
 
@@ -389,15 +397,6 @@ describe('Util', function() {
       const vTrees = parse(`<style><pre></pre></style>`).childNodes;
 
       equal(vTrees[0].nodeName, 'style');
-      equal(vTrees[0].childNodes.length, 1);
-      equal(vTrees[0].childNodes[0].nodeName, '#text');
-      equal(vTrees[0].childNodes[0].nodeValue, '<pre></pre>');
-    });
-
-    it('will not support nested elements within <code>', () => {
-      const vTrees = parse(`<code><pre></pre></code>`).childNodes;
-
-      equal(vTrees[0].nodeName, 'code');
       equal(vTrees[0].childNodes.length, 1);
       equal(vTrees[0].childNodes[0].nodeName, '#text');
       equal(vTrees[0].childNodes[0].nodeValue, '<pre></pre>');


### PR DESCRIPTION
As noted in #209, diffHTML incorrect parses code as an element that should not have it's children parsed as HTML, like you would find with a script or style tag. This is incorrect behavior and is corrected with this changeset.