### PR TITLE
Fix issues with external markup changes

### DIFF
--- a/packages/diffhtml/lib/release.js
+++ b/packages/diffhtml/lib/release.js
@@ -13,9 +13,7 @@ export default function release(mount) {
     const { mutationObserver, oldTree } = StateCache.get(mount);
 
     // Ensure the mutation observer is cleaned up.
-    if (mutationObserver) {
-      mutationObserver.disconnect();
-    }
+    mutationObserver && mutationObserver.disconnect();
 
     StateCache.delete(mount);
 

--- a/packages/diffhtml/lib/transaction.js
+++ b/packages/diffhtml/lib/transaction.js
@@ -216,14 +216,12 @@ export default class Transaction {
     state.isDirty = false;
 
     // If MutationObserver is available, look for changes.
-    if (state.mutationObserver) {
-      state.mutationObserver.observe(mountAsHTMLEl, {
-        subtree: true,
-        childList: true,
-        attributes: true,
-        characterData: true,
-      });
-    }
+    state.mutationObserver && state.mutationObserver.observe(mountAsHTMLEl, {
+      subtree: true,
+      childList: true,
+      attributes: true,
+      characterData: true,
+    });
 
     // Execute all queued scripts.
     scriptsToExecute.forEach((type = EMPTY.STR, vTree) => {

--- a/packages/diffhtml/lib/transaction.js
+++ b/packages/diffhtml/lib/transaction.js
@@ -224,6 +224,11 @@ export default class Transaction {
         characterData: true,
       });
     }
+    // If there is no MutationObserver, then the DOM is dirty by default and
+    // rescanned every time.
+    else {
+      state.isDirty = true;
+    }
 
     // Execute all queued scripts.
     scriptsToExecute.forEach((type = EMPTY.STR, vTree) => {

--- a/packages/diffhtml/lib/transaction.js
+++ b/packages/diffhtml/lib/transaction.js
@@ -12,6 +12,7 @@ import {
 import { gc } from './util/memory';
 import makeMeasure from './util/make-measure';
 import process from './util/process';
+import globalThis from './util/global';
 import schedule from './tasks/schedule';
 import shouldUpdate from './tasks/should-update';
 import reconcileTrees from './tasks/reconcile-trees';
@@ -129,11 +130,15 @@ export default class Transaction {
     this.input = input;
     this.config = config;
 
+    const isDirtyCheck = () => this.state.isDirty = true;
+    const hasMutationObserver = 'MutationObserver' in globalThis.window;
+
     this.state = StateCache.get(mount) || /** @type {TransactionState} */ ({
       measure: makeMeasure(this),
       svgElements: new Set(),
       scriptsToExecute: new Map(),
       activeTransaction: this,
+      mutationObserver: hasMutationObserver && new globalThis.window.MutationObserver(isDirtyCheck),
     });
 
     this.tasks = /** @type {Function[]} */ (
@@ -194,8 +199,9 @@ export default class Transaction {
    * @return {Transaction}
    */
   end() {
-    const { state, mount, config: options } = this;
+    const { state, config, mount } = this;
     const { measure, svgElements, scriptsToExecute } = state;
+
     const mountAsHTMLEl = /** @type {HTMLElement} */ (mount);
 
     measure('finalize');
@@ -207,7 +213,19 @@ export default class Transaction {
 
     // Rendering is complete.
     state.isRendering = false;
+    state.isDirty = false;
 
+    // If MutationObserver is available, look for changes.
+    if (state.mutationObserver) {
+      state.mutationObserver.observe(mountAsHTMLEl, {
+        subtree: true,
+        childList: true,
+        attributes: true,
+        characterData: true,
+      });
+    }
+
+    // Execute all queued scripts.
     scriptsToExecute.forEach((type = EMPTY.STR, vTree) => {
       const oldNode = /** @type {HTMLElement} */ (NodeCache.get(vTree));
 
@@ -222,7 +240,7 @@ export default class Transaction {
     // Only execute scripts if the configuration is set. By default this is set
     // to true. You can toggle this behavior for your app to disable script
     // execution.
-    if (options.executeScripts) {
+    if (config.executeScripts) {
       // Execute deferred scripts.
       scriptsToExecute.forEach((_, vTree)=> {
         const oldNode = NodeCache.get(vTree);

--- a/packages/diffhtml/lib/transaction.js
+++ b/packages/diffhtml/lib/transaction.js
@@ -131,14 +131,14 @@ export default class Transaction {
     this.config = config;
 
     const isDirtyCheck = () => this.state.isDirty = true;
-    const hasMutationObserver = 'MutationObserver' in globalThis.window || EMPTY.OBJ;
+    const hasObserver = 'MutationObserver' in (globalThis.window || EMPTY.OBJ);
 
     this.state = StateCache.get(mount) || /** @type {TransactionState} */ ({
       measure: makeMeasure(this),
       svgElements: new Set(),
       scriptsToExecute: new Map(),
       activeTransaction: this,
-      mutationObserver: hasMutationObserver && new globalThis.window.MutationObserver(isDirtyCheck),
+      mutationObserver: hasObserver && new globalThis.window.MutationObserver(isDirtyCheck),
     });
 
     this.tasks = /** @type {Function[]} */ (

--- a/packages/diffhtml/lib/transaction.js
+++ b/packages/diffhtml/lib/transaction.js
@@ -131,7 +131,7 @@ export default class Transaction {
     this.config = config;
 
     const isDirtyCheck = () => this.state.isDirty = true;
-    const hasMutationObserver = 'MutationObserver' in globalThis.window;
+    const hasMutationObserver = 'MutationObserver' in globalThis.window || EMPTY.OBJ;
 
     this.state = StateCache.get(mount) || /** @type {TransactionState} */ ({
       measure: makeMeasure(this),
@@ -216,12 +216,14 @@ export default class Transaction {
     state.isDirty = false;
 
     // If MutationObserver is available, look for changes.
-    state.mutationObserver && state.mutationObserver.observe(mountAsHTMLEl, {
-      subtree: true,
-      childList: true,
-      attributes: true,
-      characterData: true,
-    });
+    if (mountAsHTMLEl.ownerDocument && state.mutationObserver) {
+      state.mutationObserver.observe(mountAsHTMLEl, {
+        subtree: true,
+        childList: true,
+        attributes: true,
+        characterData: true,
+      });
+    }
 
     // Execute all queued scripts.
     scriptsToExecute.forEach((type = EMPTY.STR, vTree) => {

--- a/packages/diffhtml/lib/util/types.js
+++ b/packages/diffhtml/lib/util/types.js
@@ -226,7 +226,9 @@ export const Supplemental = EMPTY.OBJ;
  * @property {ValidInput=} markup
  * @property {VTree=} oldTree
  * @property {Boolean=} isRendering
+ * @property {Boolean=} isDirty
  * @property {String=} previousMarkup
+ * @property {MutationObserver=} mutationObserver
  * @property {import('../transaction').default} activeTransaction
  * @property {import('../transaction').default=} nextTransaction
  * @property {Document=} ownerDocument

--- a/packages/diffhtml/package.json
+++ b/packages/diffhtml/package.json
@@ -44,7 +44,7 @@
     "babel-plugin-istanbul": "^6.0.0",
     "babel-preset-diffhtml-imports": "^1.0.0-beta.18",
     "coveralls": "^3.1.0",
-    "jsdom": "^16.4.0",
+    "jsdom": "^16.5.3",
     "mocha": "^8.2.1",
     "nyc": "^15.1.0",
     "rollup": "^1.21.4",

--- a/packages/diffhtml/test/tasks.js
+++ b/packages/diffhtml/test/tasks.js
@@ -58,7 +58,6 @@ describe('Tasks', function() {
 
       reconcileTrees(transaction);
 
-      transaction.state.previousMarkup = this.fixture.outerHTML;
       transaction.state.oldTree = transaction.oldTree;
 
       const { oldTree } = transaction;
@@ -85,7 +84,6 @@ describe('Tasks', function() {
 
       reconcileTrees(transaction);
 
-      transaction.state.previousMarkup = this.fixture.outerHTML;
       transaction.state.oldTree = transaction.oldTree;
 
       deepStrictEqual(transaction.oldTree, {
@@ -97,6 +95,9 @@ describe('Tasks', function() {
         childNodes: [],
         attributes: {},
       });
+
+      // Start mutation observer for changes.
+      transaction.end();
 
       // Change the markup slightly.
       this.fixture.appendChild(document.createElement('span'));

--- a/packages/diffhtml/test/transaction.js
+++ b/packages/diffhtml/test/transaction.js
@@ -323,6 +323,15 @@ describe('Transaction', function() {
       strictEqual(transaction.completed, true);
     });
 
+    it('will set the state', () => {
+      const { mount, input, config } = suite;
+      const transaction = Transaction.create(mount, input, config);
+
+      transaction.end();
+
+      strictEqual(transaction.state.previousMarkup, '<div></div>');
+    });
+
     it('will change isRendering', () => {
       const { mount, input, config } = suite;
       const transaction = Transaction.create(mount, input, config);

--- a/packages/diffhtml/test/transaction.js
+++ b/packages/diffhtml/test/transaction.js
@@ -323,15 +323,6 @@ describe('Transaction', function() {
       strictEqual(transaction.completed, true);
     });
 
-    it('will set the state', () => {
-      const { mount, input, config } = suite;
-      const transaction = Transaction.create(mount, input, config);
-
-      transaction.end();
-
-      strictEqual(transaction.state.previousMarkup, '<div></div>');
-    });
-
     it('will change isRendering', () => {
       const { mount, input, config } = suite;
       const transaction = Transaction.create(mount, input, config);

--- a/packages/diffhtml/test/use.js
+++ b/packages/diffhtml/test/use.js
@@ -190,7 +190,21 @@ describe('Use (Middleware)', function() {
     release(oldTree);
   });
 
-  it('will reconcile the new dom when the same markup is used', () => {
+  it('will reconcile the new dom when the same markup is used in the mounted element', () => {
+    const fixture = document.createElement('div');
+
+    innerHTML(fixture, '<p><span></span></p>');
+
+    fixture.innerHTML = fixture.innerHTML;
+
+    innerHTML(fixture, '<p></p><p><span></span></p>');
+
+    equal(fixture.innerHTML, '<p></p><p><span></span></p>');
+
+    release(fixture);
+  });
+
+  it('will reconcile the new dom when the same markup is used in a nested element', () => {
     const fixture = document.createElement('div');
 
     innerHTML(fixture, '<p><span></span></p>');
@@ -204,7 +218,7 @@ describe('Use (Middleware)', function() {
     release(fixture);
   });
 
-  it('will ignoring a dynamically added DOM Node to avoid diffing', () => {
+  it('will ignore a dynamically added DOM Node to avoid diffing', () => {
     const fixture = document.createElement('div');
 
     innerHTML(fixture, '<p></p>');

--- a/packages/diffhtml/test/use.js
+++ b/packages/diffhtml/test/use.js
@@ -190,6 +190,20 @@ describe('Use (Middleware)', function() {
     release(oldTree);
   });
 
+  it('will reconcile the new dom when the same markup is used', () => {
+    const fixture = document.createElement('div');
+
+    innerHTML(fixture, '<p><span></span></p>');
+
+    fixture.querySelector('p').innerHTML = fixture.querySelector('p').innerHTML;
+
+    innerHTML(fixture, '<p></p><p><span></span></p>');
+
+    equal(fixture.outerHTML, '<div><p></p><p><span></span></p></div>');
+
+    release(fixture);
+  });
+
   it('will ignoring a dynamically added DOM Node to avoid diffing', () => {
     const fixture = document.createElement('div');
 


### PR DESCRIPTION
This fixes #217 by using a MutationObserver to detect whenever the DOM changes and becomes dirty after a render. This appears to the best way to reliably know if the DOM has changed under the element. `outerHTML` is not sufficient as markup may be identical, but the Nodes have changed.