### PR TITLE
Fix bool attr parsing

### DIFF
--- a/packages/babel-plugin-transform-diffhtml/lib/index.js
+++ b/packages/babel-plugin-transform-diffhtml/lib/index.js
@@ -294,7 +294,7 @@ export default function({ types: t }) {
           // tokens and inject.
           attributes.properties.forEach((property, i, properties) => {
             const keysMatched = property.key.value.split(tokenEx);
-            const valuesMatched = property.value.value.split(tokenEx);
+            const valuesMatched = String(property.value.value).split(tokenEx);
 
             const keys = [];
             const values = [];

--- a/packages/diffhtml/lib/to-string.js
+++ b/packages/diffhtml/lib/to-string.js
@@ -63,6 +63,10 @@ function serializeAttributes(attributes) {
     const isFalsy = !value;
     const isDynamic = typeof value === 'object' || typeof value === 'function';
 
+    if (value === true) {
+      return keyName;
+    }
+
     return `${keyName}${(!isFalsy && !isDynamic) ? `="${String(value)}"` : ''}`;
   }).join(' ') : '';
 }

--- a/packages/diffhtml/test/html.js
+++ b/packages/diffhtml/test/html.js
@@ -70,7 +70,7 @@ describe('HTML (Tagged template)', function() {
     const checked = 'checked';
     const input = html`<input type="checkbox" ${checked}>`;
 
-    equal(input.attributes.checked, 'checked');
+    equal(input.attributes.checked, true);
   });
 
   it('will interpolate multiple type values in an attribute', function() {

--- a/packages/diffhtml/test/to-string.js
+++ b/packages/diffhtml/test/to-string.js
@@ -59,7 +59,7 @@ describe('toString', function() {
 
   it('can render a value-less attribute', () => {
     const actual = toString(html`<div disabled/>`);
-    const expected = `<div disabled="disabled"></div>`;
+    const expected = `<div disabled></div>`;
 
     strictEqual(actual, expected);
   });

--- a/packages/diffhtml/test/util.js
+++ b/packages/diffhtml/test/util.js
@@ -141,7 +141,7 @@ describe('Util', function() {
       const vTree = parse('<option value="test" selected></option>').childNodes[0];
 
       strictEqual(vTree.attributes.value, 'test');
-      strictEqual(vTree.attributes.selected, 'selected');
+      strictEqual(vTree.attributes.selected, true);
     });
 
     it('will support quote-less values', () => {
@@ -264,7 +264,7 @@ describe('Util', function() {
       const vTrees = parse(`<input ${token}/>`).childNodes;
 
       strictEqual(vTrees[0].nodeName, 'input');
-      deepStrictEqual(vTrees[0].attributes, { [token]: token });
+      deepStrictEqual(vTrees[0].attributes, { [token]: true });
     });
 
     it('will parse out partial attributes', () => {
@@ -290,7 +290,7 @@ describe('Util', function() {
       const vTrees = parse(`<input ${token}/>`, supplemental).childNodes;
 
       strictEqual(vTrees[0].nodeName, 'input');
-      deepStrictEqual(vTrees[0].attributes, { disabled: 'disabled' });
+      deepStrictEqual(vTrees[0].attributes, { disabled: true });
     });
 
     it('will support passing childNodes as an attribute', () => {
@@ -863,7 +863,7 @@ describe('Util', function() {
           key: '',
           childNodes: [],
           attributes: {
-            checked,
+            checked: true,
           },
         }],
         attributes: {},


### PR DESCRIPTION
Fixes issue GH-242

Supports better parsing around attributes. Instead of simply mirroring keys like disabled to serve as the value, instead determine if a `true` value is more appropriate.