### PR TITLE
set boolean attributes as '' (not 'true')

### DIFF
--- a/packages/diffhtml/lib/node/patch.js
+++ b/packages/diffhtml/lib/node/patch.js
@@ -69,7 +69,7 @@ const setAttribute = (vTree, domNode, name, value) => {
     const noValue = value === null || value === undefined;
 
     // If we cannot set the value as a property, try as an attribute.
-    htmlElement.setAttribute(lowerName, noValue ? EMPTY.STR : value);
+    htmlElement.setAttribute(lowerName, noValue ? EMPTY.STR : (value === true ? '' : value));
   }
   // Support patching an object representation of the style object.
   else if (isObject && lowerName === 'style') {


### PR DESCRIPTION
This brings https://github.com/tbranyen/diffhtml/issues/242 to conclusion.

With input:

```html
<video controls></video>
```

we get

before #242:

```html
<video controls="controls"></video>
```

after #242:

```html
<video controls="true"></video>
```

after this pull request:

```html
<video controls></video>
```

---

<details><summary>Intentional/explicit <code>"true"</code> as string in the input, works the same, as desired, before/after this pull request.</summary>

input:

```html
<a title="true">x</a>
```

after this pull request:

```html
<a title="true">x</a>
```

</details>