### PR TITLE
Fixes issues with scripts in Firefox

### DIFF
--- a/packages/diffhtml/lib/util/types.js
+++ b/packages/diffhtml/lib/util/types.js
@@ -225,7 +225,6 @@ export const Supplemental = EMPTY.OBJ;
  * @property {VTree=} oldTree
  * @property {Boolean=} isRendering
  * @property {Boolean=} isDirty
- * @property {String=} previousMarkup
  * @property {MutationObserver=} mutationObserver
  * @property {import('../transaction').default} activeTransaction
  * @property {import('../transaction').default=} nextTransaction

--- a/packages/diffhtml/test/transaction.js
+++ b/packages/diffhtml/test/transaction.js
@@ -322,15 +322,6 @@ describe('Transaction', function() {
       strictEqual(transaction.completed, true);
     });
 
-    it('will set the state', () => {
-      const { mount, input, config } = suite;
-      const transaction = Transaction.create(mount, input, config);
-
-      transaction.end();
-
-      strictEqual(transaction.state.previousMarkup, '<div></div>');
-    });
-
     it('will change isRendering', () => {
       const { mount, input, config } = suite;
       const transaction = Transaction.create(mount, input, config);


### PR DESCRIPTION
Takes advice from #249 and creates a new script element and mirrors the existing contents and attributes/properties into it. Should be functionally equivalent to using `domNode.cloneNode`. This fixes a problem in Firefox where changing a scripts type attribute has no effect (once added to the dom), unlike in Chrome. 