### PR TITLE
Implements createSideEffect

### DIFF
--- a/packages/diffhtml-components/lib/create-side-effect.js
+++ b/packages/diffhtml-components/lib/create-side-effect.js
@@ -2,13 +2,16 @@ import { $$hooks } from './util/symbols';
 import { EMPTY, ActiveRenderState } from './util/types';
 
 /**
- * Allow a function component to hook into lifecycle in a manner consistent
- * with class components.
+ * Allow a function component to hook into lifecycle methods in a manner
+ * consistent with class components.
  *
- * @param {Function} sideEffectFn
+ * @param {Function} sideEffectFn - A function that is called whenever the
+ * component is mounted or updated. To invoke cleanup pass a second function
+ * which will run whenever the component is removed.
+ *
  * @returns {void}
  */
-export function createSideEffect(sideEffectFn = EMPTY.FUN) {
+export function createSideEffect(sideEffectFn) {
   if (ActiveRenderState.length === 0) {
     throw new Error('Cannot create side effect unless in render function');
   }
@@ -22,15 +25,9 @@ export function createSideEffect(sideEffectFn = EMPTY.FUN) {
 
   // Only do this the first time.
   if (!activeHook) {
-    /** @type {function} */
-    let unMount = EMPTY.FUN;
-
     // First schedule a componentDidMount
     activeComponent.componentDidMount = activeComponent.componentDidUpdate = () => {
-      // Always unmount first
-      unMount();
-
-      unMount = sideEffectFn() || EMPTY.FUN;
+      const unMount = sideEffectFn() || EMPTY.FUN;
 
       if (typeof unMount === 'function') {
         activeComponent.componentWillUnmount = () => unMount();

--- a/packages/diffhtml-components/lib/create-side-effect.js
+++ b/packages/diffhtml-components/lib/create-side-effect.js
@@ -1,0 +1,43 @@
+import { $$hooks } from './util/symbols';
+import { EMPTY, ActiveRenderState } from './util/types';
+
+/**
+ * Allow a function component to hook into lifecycle in a manner consistent
+ * with class components.
+ *
+ * @param {Function} sideEffectFn
+ * @returns {void}
+ */
+export function createSideEffect(sideEffectFn = EMPTY.FUN) {
+  if (ActiveRenderState.length === 0) {
+    throw new Error('Cannot create side effect unless in render function');
+  }
+
+  if (typeof sideEffectFn !== 'function') {
+    throw new Error('Missing function for side effect');
+  }
+
+  const [ activeComponent ] = ActiveRenderState;
+  const activeHook = activeComponent[$$hooks].shift();
+
+  // Only do this the first time.
+  if (!activeHook) {
+    /** @type {function} */
+    let unMount = EMPTY.FUN;
+
+    // First schedule a componentDidMount
+    activeComponent.componentDidMount = activeComponent.componentDidUpdate = () => {
+      // Always unmount first
+      unMount();
+
+      unMount = sideEffectFn() || EMPTY.FUN;
+
+      if (typeof unMount === 'function') {
+        activeComponent.componentWillUnmount = () => unMount();
+      }
+    };
+
+    // Return currentValue and setState.
+    activeComponent[$$hooks].push(sideEffectFn);
+  }
+}

--- a/packages/diffhtml-components/lib/create-state.js
+++ b/packages/diffhtml-components/lib/create-state.js
@@ -29,7 +29,7 @@ export function createState(defaultValue = {}) {
    */
   const setState = newValue => {
     retVal[0] = newValue;
-    activeComponent.forceUpdate();
+    return activeComponent.forceUpdate();
   };
 
   if (retVal.length === 1) {

--- a/packages/diffhtml-components/lib/index.js
+++ b/packages/diffhtml-components/lib/index.js
@@ -1,5 +1,6 @@
 import * as Internals from './util/internals';
 
 export { createState } from './create-state';
+export { createSideEffect } from './create-side-effect';
 export { default as Component } from './component';
 export { Internals };

--- a/packages/diffhtml-components/lib/once-ended.js
+++ b/packages/diffhtml-components/lib/once-ended.js
@@ -7,6 +7,10 @@ const { NodeCache, PATCH_TYPE, decodeEntities } = diff.Internals;
 const uppercaseEx = /[A-Z]/g;
 
 /**
+ * Once the transaction has ended we can know for certain that DOM operations
+ * have completed and can trigger lifecycle methods like componentDidMount or
+ * componentWillUnmount.
+ *
  * @param {Transaction} transaction
  */
 export default transaction => {
@@ -22,6 +26,7 @@ export default transaction => {
   while (true) {
     const patchType = patches[i];
 
+    // Exhausted remaining patches.
     if (i === length) {
       break;
     }

--- a/packages/diffhtml-components/lib/render-component.js
+++ b/packages/diffhtml-components/lib/render-component.js
@@ -119,7 +119,16 @@ export default function renderComponent(vTree) {
     // Allow hooks to "hook" into the active rendering component.
     ActiveRenderState.push(instance);
 
-    const renderRetVal = instance.render(props, instance.state);
+    let renderRetVal = null;
+
+    try {
+      renderRetVal = instance.render(props, instance.state);
+    }
+    catch (e) {
+      // Clean up after a potential failure.
+      ActiveRenderState.length = 0;
+      throw e;
+    }
 
     ActiveRenderState.length = 0;
 

--- a/packages/diffhtml-components/lib/util/types.js
+++ b/packages/diffhtml-components/lib/util/types.js
@@ -5,6 +5,7 @@ export const EMPTY = {
   OBJ: {},
   ARR: [],
   BOOL: true,
+  FUN: () => {},
 };
 
 /**

--- a/packages/diffhtml-components/test/integration/hooks.js
+++ b/packages/diffhtml-components/test/integration/hooks.js
@@ -1,0 +1,196 @@
+import { strictEqual, deepStrictEqual, throws, fail, ok } from 'assert';
+import { createSideEffect } from '../../lib/create-side-effect';
+import { createState } from '../../lib/create-state';
+import diff from '../../lib/util/binding';
+import globalThis from '../../lib/util/global';
+import { ComponentTreeCache } from '../../lib/util/types';
+import validateCaches from '../util/validate-caches';
+
+const { html, release, innerHTML, toString, createTree } = diff;
+const { document } = globalThis;
+
+describe('Hooks', function() {
+  beforeEach(async () => {
+    process.env.NODE_ENV = 'development';
+    newJSDOMSandbox();
+    (await import('../../lib/component')).default.subscribeMiddleware();
+  });
+
+  afterEach(async () => {
+    release(this.fixture);
+    (await import('../../lib/component')).default.unsubscribeMiddleware();
+    validateCaches();
+  });
+
+  describe('createSideEffect', () => {
+    it('will error when executed outside a render function', () => {
+      throws(() => {
+        createSideEffect(() => {});
+      }, /Cannot create side effect unless in render function/);
+    });
+
+    it('will error when not passed a function', () => {
+      function Component() {
+        createSideEffect();
+
+        return html`<div></div>`;
+      }
+
+      this.fixture = document.createElement('div');
+
+      throws(() => {
+        innerHTML(this.fixture, html`<${Component} />`)
+      }, /Missing function for side effect/);
+    });
+
+    it('will support componentDidMount', async () => {
+      let firedOnMount = 0;
+
+      function Component() {
+        createSideEffect(() => {
+          firedOnMount++;
+        });
+
+        return html`<div></div>`;
+      }
+
+      this.fixture = document.createElement('div');
+
+      await innerHTML(this.fixture, html`<${Component} />`);
+
+      strictEqual(firedOnMount, 1);
+    });
+
+    it('will support componentWillUnmount', async () => {
+      let firedOnMount = 0;
+
+      function Component() {
+        createSideEffect(() => {
+          firedOnMount++;
+        });
+
+        return html`<div></div>`;
+      }
+
+      this.fixture = document.createElement('div');
+
+      await innerHTML(this.fixture, html`<${Component} />`);
+
+      strictEqual(firedOnMount, 1);
+    });
+
+    it('will support componentDidUpdate', async () => {
+      let firedOnUpdate = 0;
+
+      function Component() {
+        createSideEffect(() => {
+          firedOnUpdate++;
+        });
+
+        return html`<div></div>`;
+      }
+
+      this.fixture = document.createElement('div');
+
+      await innerHTML(this.fixture, html`<${Component} />`);
+      await innerHTML(this.fixture, html`<${Component} test="true" />`);
+
+      strictEqual(firedOnUpdate, 2);
+    });
+
+    it('will support componentDidUpdate through forceUpdate', async () => {
+      let firedOnUpdate = 0;
+
+      function Component() {
+        createSideEffect(() => {
+          firedOnUpdate++;
+        });
+
+        return html`<div></div>`;
+      }
+
+      this.fixture = document.createElement('div');
+
+      let component = null;
+
+      await innerHTML(this.fixture, html`<${Component} ref=${ref => (component = ref)} />`);
+      await component.forceUpdate();
+
+      strictEqual(firedOnUpdate, 2);
+    });
+
+    it('will support componentWillUnmount', async () => {
+      let firedOnUnmount = 0;
+
+      function Component() {
+        createSideEffect(() => () => {
+          firedOnUnmount++;
+        });
+
+        return html`<div></div>`;
+      }
+
+      this.fixture = document.createElement('div');
+
+      await innerHTML(this.fixture, html`<${Component} />`);
+      await innerHTML(this.fixture, html``);
+
+      strictEqual(firedOnUnmount, 1);
+    });
+  });
+
+  describe('createState', () => {
+    it('will error when executed outside a render function', () => {
+      throws(() => {
+        createState();
+      }, /Cannot create state unless in render function/);
+    });
+
+    it('will use an object as a default value', async () => {
+      function Component() {
+        const [ value ] = createState();
+
+        return html`${JSON.stringify(value)}`;
+      }
+
+      this.fixture = document.createElement('div');
+
+      await innerHTML(this.fixture, html`<${Component} />`);
+
+      strictEqual(this.fixture.outerHTML, `<div>{}</div>`);
+    });
+
+    it('will support passing a default value', async () => {
+      function Component() {
+        const [ value ] = createState(false);
+
+        return html`${String(value)}`;
+      }
+
+      this.fixture = document.createElement('div');
+
+      await innerHTML(this.fixture, html`<${Component} />`);
+
+      strictEqual(this.fixture.outerHTML, `<div>false</div>`);
+    });
+
+    it('will support updating the state', async () => {
+      let setValue = null;
+
+      function Component() {
+        const [ value, _setValue ] = createState(false);
+
+        setValue = _setValue;
+
+        return html`${String(value)}`;
+      }
+
+      this.fixture = document.createElement('div');
+
+      await innerHTML(this.fixture, html`<${Component} />`);
+      await setValue(true);
+
+      strictEqual(this.fixture.outerHTML, `<div>true</div>`);
+    });
+  });
+});

--- a/packages/diffhtml-components/test/util/validate-caches.js
+++ b/packages/diffhtml-components/test/util/validate-caches.js
@@ -1,11 +1,12 @@
 import { strictEqual } from 'assert';
 import diff from '../../lib/util/binding';
-import { ComponentTreeCache, InstanceCache } from '../../lib/util/types';
+import { ActiveRenderState, ComponentTreeCache, InstanceCache } from '../../lib/util/types';
 
 /**
  * Validates that the caches has been successfully cleaned per render.
  */
 export default function validateCaches() {
+  strictEqual(ActiveRenderState.length, 0, 'The ActiveRenderState global should be empty');
   strictEqual(ComponentTreeCache.size, 0, 'The ComponentTree cache should be empty');
   strictEqual(InstanceCache.size, 0, 'The instance cache should be empty');
 

--- a/packages/diffhtml-website/pages/components.md
+++ b/packages/diffhtml-website/pages/components.md
@@ -211,6 +211,8 @@ The function `createState` is used to make a stateful component out of a
 function component. It mimics the API of `useState` from React. Essentially you
 must execute this function in the same spot at the same time every render.
 
+This API is similar to `useState` from React.
+
 <a name="create-state-examples"></a>
 
 ### <a href="#create-state-examples"><u>Examples</u></a>
@@ -241,7 +243,10 @@ innerHTML(main, html`<${Example} />`);
 ## <a href="#create-side-effect">createSideEffect</a>
 
 The function `createSideEffect` is used to schedule some work after a component
-has updated.
+has mounted, unmounted, or updated. This works similar to the `useEffect` hook
+found in React.
+
+This API is similar to `useEffect` from React.
 
 <a name="create-side-effect-examples"></a>
 
@@ -253,7 +258,11 @@ import { createSideEffect } from 'diffhtml-components';
 
 function Example() {
   createSideEffect(() => {
-    console.log('Component has rendered');
+    console.log('Component has mounted or updated');
+
+    return () => {
+      console.log('Component has unmounted');
+    };
   });
 
   return html`


### PR DESCRIPTION
This introduces `createSideEffect` which matches `useEffect` from React. It is currently incomplete, but in a somewhat usable form. I need to do some refactoring around how/when we call lifecycle methods as the current approach isn't entirely accurate.

Right now we call `componentWillUnmount` after patching, which is not right, it should happen before the element actually unmounts.