### PR TITLE
Supports set vs remove attribute

### DIFF
--- a/packages/diffhtml/lib/html.js
+++ b/packages/diffhtml/lib/html.js
@@ -147,7 +147,13 @@ delete /** @type {any} */(handleTaggedTemplate)[$$strict];
  */
 function setStrictMode(markup, ...args) {
   /** @type {any} */(handleTaggedTemplate)[$$strict] = true;
-  return handleTaggedTemplate(markup, ...args);
+  try {
+    return handleTaggedTemplate(markup, ...args);
+  }
+  catch (e) {
+    /** @type {any} */(handleTaggedTemplate)[$$strict] = false;
+    throw e;
+  }
 }
 
 handleTaggedTemplate.strict = setStrictMode;

--- a/packages/diffhtml/lib/node/patch.js
+++ b/packages/diffhtml/lib/node/patch.js
@@ -38,7 +38,7 @@ const setAttribute = (vTree, domNode, name, value) => {
   const lowerName = isEvent ? name.toLowerCase() : name;
 
   // Runtime checking if the property can be set.
-  const blocklistName = vTree.nodeName + '-' + lowerName;
+  const blocklistName = 's-' + vTree.nodeName + '-' + lowerName;
 
   /** @type {HTMLElement} */
   const htmlElement = /** @type {any} */ (domNode);
@@ -86,7 +86,7 @@ const setAttribute = (vTree, domNode, name, value) => {
  */
 const removeAttribute = (vTree, domNode, name) => {
   // Runtime checking if the property can be set.
-  const blocklistName = vTree.nodeName + '-' + name;
+  const blocklistName = 'r-' + vTree.nodeName + '-' + name;
   const anyNode = /** @type {any} */ (domNode);
 
   if (allowlist.has(blocklistName)) {

--- a/packages/diffhtml/test/integration/basics.js
+++ b/packages/diffhtml/test/integration/basics.js
@@ -165,6 +165,20 @@ describe('Integration: Basics', function() {
 
       diff.Internals.memory.gc();
     });
+
+    it('will support safely removing properties with delete disabled', function() {
+      const element = new Proxy(document.createElement('div'), {
+        deleteProperty() {
+          throw new Error('Should not cause uncaught failure');
+        }
+      });
+
+      assert.doesNotThrow(() => {
+        diff.outerHTML(element, diff.html`<div of="true" />`);
+        diff.outerHTML(element, diff.html`<div />`);
+        diff.release(element);
+      });
+    });
   });
 
   describe('Special features', function() {


### PR DESCRIPTION
Closes GH-261, allows patching to more safely remove attributes that have been designed to not allow the `delete` operator on them.