### PR TITLE
HTML Parser Rewrite

### DIFF
--- a/packages/babel-plugin-transform-diffhtml/lib/index.js
+++ b/packages/babel-plugin-transform-diffhtml/lib/index.js
@@ -135,7 +135,6 @@ export default function({ types: t }) {
   const visitor = {
     TaggedTemplateExpression(path, plugin) {
       let tagName = '';
-      let strict = false;
 
       if (path.node.tag.type === 'Identifier') {
         tagName = path.node.tag.name
@@ -150,10 +149,6 @@ export default function({ types: t }) {
 
       if (tagName.indexOf((plugin.opts.tagName || 'html')) !== 0) {
         return;
-      }
-
-      if (tagName === `${plugin.opts.tagName || 'html'}.strict`) {
-        strict = true;
       }
 
       const supplemental = {
@@ -242,7 +237,7 @@ export default function({ types: t }) {
       // serializing later. Using WASM the objects returned have getters which
       // are lost to the JSON.stringify call. By using createTree the values
       // are plucked and applied to the VTree object.
-      const root = createTree(Internals.parse(HTML, null, { strict })).childNodes;
+      const root = createTree(Internals.parse(HTML)).childNodes;
       const strRoot = JSON.stringify(root.length === 1 ? root[0] : root);
       const vTree = babylon.parse('(' + strRoot + ')');
 

--- a/packages/diffhtml-components/lib/render-component.js
+++ b/packages/diffhtml-components/lib/render-component.js
@@ -109,7 +109,7 @@ export default function renderComponent(vTree, transaction) {
       render(props, state) {
         // Always render the latest `rawNodeName` of a VTree in case of
         // hot-reloading the cached value above wouldn't be correct.
-        return createTree(vTree.rawNodeName(props, state));
+        return createTree(RawComponent(props, state));
       }
 
       /** @type {VTree | null} */

--- a/packages/diffhtml-components/test/component.js
+++ b/packages/diffhtml-components/test/component.js
@@ -244,11 +244,12 @@ describe('Component', function() {
       strictEqual(componentVTree.rawNodeName, TestComponent);
     });
 
-    it('will associate the whitespace from the start of a fragment', () => {
+    it('will associate the first element from the start of a fragment', () => {
       class TestComponent extends Component {
         render() {
           return html`
             <div />
+            <p />
           `;
         }
       }
@@ -257,8 +258,6 @@ describe('Component', function() {
       innerHTML(this.fixture, TestComponent);
 
       const componentVTree = ComponentTreeCache.get(this.fixture.childNodes[0]);
-      // FIXME This should be a comment to make it more portable. Although text
-      // will work for now.
       strictEqual(this.fixture.childNodes[0].nodeName, '#text');
       strictEqual(componentVTree.rawNodeName, TestComponent);
     });
@@ -617,7 +616,7 @@ describe('Component', function() {
 
       const instance = this.fixture.querySelector('custom-component');
 
-      strictEqual(instance.shadowRoot.childNodes[1].outerHTML, '<div>Hello world</div>');
+      strictEqual(instance.shadowRoot.childNodes[0].outerHTML, '<div>Hello world</div>');
       strictEqual(this.fixture.innerHTML, '<div><custom-component></custom-component></div>');
     });
 
@@ -640,7 +639,7 @@ describe('Component', function() {
 
       const instance = this.fixture.querySelector('custom-component');
 
-      strictEqual(instance.shadowRoot.childNodes[1].outerHTML, '<div>Hello world</div>');
+      strictEqual(instance.shadowRoot.childNodes[0].outerHTML, '<div>Hello world</div>');
       strictEqual(this.fixture.innerHTML, '<custom-component></custom-component>');
     });
 

--- a/packages/diffhtml-components/test/integration/web-component.js
+++ b/packages/diffhtml-components/test/integration/web-component.js
@@ -53,7 +53,7 @@ describe('Web Component', function() {
 
     const instance = this.fixture.querySelector('custom-component');
 
-    equal(instance.shadowRoot.childNodes[1].outerHTML, '<div>Hello world</div>');
+    equal(instance.shadowRoot.childNodes[0].outerHTML, '<div>Hello world</div>');
     equal(this.fixture.innerHTML, '<custom-component></custom-component>');
   });
 
@@ -71,7 +71,7 @@ describe('Web Component', function() {
 
     const instance = this.fixture.querySelector('custom-component');
 
-    equal(instance.shadowRoot.childNodes[1].outerHTML, '<div>Hello world</div>');
+    equal(instance.shadowRoot.childNodes[0].outerHTML, '<div>Hello world</div>');
     equal(this.fixture.innerHTML, '<div><custom-component></custom-component></div>');
   });
 
@@ -91,7 +91,7 @@ describe('Web Component', function() {
 
     const instance = this.fixture.querySelector('custom-component');
 
-    equal(instance.shadowRoot.childNodes[1].outerHTML, '<div>Hello world</div>');
+    equal(instance.shadowRoot.childNodes[0].outerHTML, '<div>Hello world</div>');
     equal(this.fixture.innerHTML, '<custom-component></custom-component>');
   });
 
@@ -217,7 +217,7 @@ describe('Web Component', function() {
 
     const instance = this.fixture.querySelector('custom-component');
 
-    equal(instance.shadowRoot.childNodes[1].outerHTML, '<div>Hello world</div>');
+    equal(instance.shadowRoot.childNodes[0].outerHTML, '<div>Hello world</div>');
     equal(this.fixture.innerHTML, '<div><custom-component></custom-component></div>');
   });
 
@@ -301,7 +301,7 @@ describe('Web Component', function() {
     const inner = this.fixture.querySelector('inner-component');
 
     equal(
-      instance.shadowRoot.childNodes[1].outerHTML,
+      instance.shadowRoot.childNodes[0].outerHTML,
       '<div><slot></slot></div>',
     );
 

--- a/packages/diffhtml-middleware-linter/lib/index.js
+++ b/packages/diffhtml-middleware-linter/lib/index.js
@@ -1,30 +1,39 @@
 const { assign, keys } = Object;
 const { isArray } = Array;
 
+/**
+ * @see https://htmlhint.com/docs/user-guide/list-rules
+ */
 const defaults = {
-  "tagname-lowercase": true,
+  // Doctype and Head
+  "doctype-first": true,                  // requires parser change
+  "doctype-html5": true,                  // requires parser change
+  "html-lang-require": true,              // requires parser change
+  "head-script-disabled": true,
+  "style-disabled": false,
+  "script-disabled": false,
+  "title-require": true,
+
+  // Attributes
   "attr-lowercase": true,
+  "attr-no-duplication": true,            // requires parser change
+  "attr-no-unnecessary-whitespace": true, // requires parser change
   "attr-value-double-quotes": true,       // requires parser change
   "attr-value-not-empty": false,
-  "attr-no-duplication": true,            // requires parser change
-  "doctype-first": true,                  // requires parser change
   "tag-pair": true,                       // requires parser change
   "empty-tag-not-self-closed": true,      // requires parser change
   "spec-char-escape": true,               // requires parser change
+  "tagname-lowercase": true,
   "id-unique": true,
   "src-not-empty": true,
-  "title-require": true,
   "alt-require": true,
-  "doctype-html5": true,                  // requires parser change
   "id-class-value": "dash",
-  "style-disabled": false,
   "inline-style-disabled": false,
   "inline-script-disabled": false,
   "space-tab-mixed-disabled": "space",    // requires parser change
   "id-class-ad-disabled": false,          // tbd
   "href-abs-or-rel": false,               // tbd
   "attr-unsafe-chars": true,
-  "head-script-disabled": true,
 };
 
 const unsafeRegexp = /[\u0000-\u0009\u000b\u000c\u000e-\u001f\u007f-\u009f\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/;

--- a/packages/diffhtml-static-sync/sync.js
+++ b/packages/diffhtml-static-sync/sync.js
@@ -82,6 +82,8 @@ function open() {
       ) {
         const children = html(markup);
 
+        console.log(children, markup);
+
         if (children.childNodes.length > 1) {
           outerHTML(document.documentElement, children.childNodes[1]);
         }

--- a/packages/diffhtml-website/components/layout.js
+++ b/packages/diffhtml-website/components/layout.js
@@ -36,27 +36,29 @@ module.exports = ({ path, page, pages, content }) => html`
       </layer>
 
       <layer id="main">
-        <div class="open-menu">≡</div>
-        <header>
-          <h1>
-            <a href="/"><img width="120" height="51" src="./images/diffhtml-logo-fit.png"></a>
-            <div>
-              <p class="name">diffHTML</p><sub>v${version}</sub>
-              <p>An easy-to-use Virtual DOM built for the web!</p>
-            </div>
-          </h1>
-        </header>
+        <div class="page-content">
+          <div class="open-menu">≡</div>
+          <header>
+            <h1>
+              <a href="/"><img width="120" height="51" src="./images/diffhtml-logo-fit.png"></a>
+              <div>
+                <p class="name">diffHTML</p><sub>v${version}</sub>
+                <p>An easy-to-use Virtual DOM built for the web!</p>
+              </div>
+            </h1>
+          </header>
 
-        <hr />
+          <hr />
 
-        <section id="content">${content}</section>
+          <section id="content">${content}</section>
 
-        <a
-          href=${`https://github.com/tbranyen/diffhtml/edit/master/packages/diffhtml-website/pages/${path.replace('.html', '.md')}`}
-          id="edit-on-github"
-        >
-          Edit on GitHub &nbsp; <span class="fa fa-github"></span>
-        </a>
+          <a
+            href=${`https://github.com/tbranyen/diffhtml/edit/master/packages/diffhtml-website/pages/${path.replace('.html', '.md')}`}
+            id="edit-on-github"
+          >
+            Edit on GitHub &nbsp; <span class="fa fa-github"></span>
+          </a>
+        </div>
 
         <footer>
           <a target="_blank" href="https://twitter.com/tbranyen" style="text-decoration: none;">

--- a/packages/diffhtml-website/config.json
+++ b/packages/diffhtml-website/config.json
@@ -22,7 +22,8 @@
 
     "Parser": ["parser.html", {
       "Options": "#options",
-      "Dynamic values": "#dynamic-values"
+      "Dynamic values": "#dynamic-values",
+      "Rust WASM": "#rust-wasm"
     }],
 
     "Middleware": ["middleware.html", {

--- a/packages/diffhtml-website/pages/api.md
+++ b/packages/diffhtml-website/pages/api.md
@@ -1,12 +1,14 @@
 # Core API
 
+The 
+
 This documentation covers the core public API. All methods and internals work
 in the browser and directly in [Node.js](https://nodejs.org/en/) with or without
 [jsdom](https://github.com/jsdom/jsdom).
 
 **Terminology:**
 
-- **VTree**: You will see them mentioned throughout the documentation. They are
+- **VTree**: The internal VDOM structure. They are
   JavaScript objects that represent a DOM node. They store information such as
   the tagName, what the childNodes are, and more. A reference to a VTree can get
   you access to the DOM node it represents. They are used throughout the
@@ -417,7 +419,7 @@ passing a config object to `innerHTML`, `outerHTML`, and `toString`.
 
 In the case of query string and environment variables, uppercase the variables
 and prefix with `DIFF_`. So `inner` becomes `DIFF_INNER`. For `parser` use a
-JSON string: `JSON.stringify({ parser: { strict: true } })`.
+JSON string: `JSON.stringify({ parser: { rawElements: ['div'] } })`.
 
 - [`inner`](#options-inner)
 - [`tasks`](#options-tasks)
@@ -534,8 +536,8 @@ innerHTML(document.body, `Some value`, {
 
 ### <a href="#options-parser">parser `Object`</a>
 
-These options modify the parser by making it more strict or changing which
-elements are treated as block or self closing.
+These options modify the parser by  changing which elements are treated as
+block or self closing.
 
 [Learn more about these options](/parser.html#options)
 
@@ -548,7 +550,7 @@ import { innerHTML } from 'diffhtml';
 
 innerHTML(document.body, `
   <h1>Hello world</h2>
-`, { parser: { strict: true } });
+`, { parser: { rawElements: ['div'] } });
 ```
 
 ---

--- a/packages/diffhtml-website/pages/index.md
+++ b/packages/diffhtml-website/pages/index.md
@@ -13,7 +13,7 @@ approachable to new programmers, intermediates, and professionals.
 - ESM/CJS/UMD + Minified ES5 builds
 - Middleware
 - Efficient Virtual DOM
-- Object pooling to optimize GC
+- Object pooling and custom HTML parser to optimize GC
 - Strict mode TypeScript via checkJS
 
 <a name="getting-started"></a>

--- a/packages/diffhtml-website/pages/parser.md
+++ b/packages/diffhtml-website/pages/parser.md
@@ -2,16 +2,21 @@
 
 One of the best features of diffHTML is the parser. This drives the compiling
 of declarative markup and supports a variety of syntaxes. You can make compound
-documents that are comprised of HTML, SVG, or XML. The result is a JSX-like
-object which is used by the core engine and the Babel transform.
+documents that are comprised of HTML, SVG, or XML. The result is a VTree which
+makes it equivalent to the `createTree` function. 
 
-When you use `innerHTML`, `outerHTML`, or `html` and pass markup, it will run
-through this very fast and efficient parser. Usually production code does not
-run the parser. You will pre-compile your markup using the [Babel
-transform](/tools.html#babel-transform).
+Usually production code does not run the parser. You will pre-compile your markup
+using the [Babel transform](/tools.html#babel-transform) that also conveniently
+uses the same parser to ensure parity.
 
-The parser can read full HTML documents including doctype, html/head/body/title
-etc tags, unwrapped fragments, and more!
+The built in parser can read full HTML documents including comments, doctype,
+html/head/body/title page tags, multiple unwrapped top-level root elements,
+and has support for optional tags. It even supports nested markup within tags,
+such as <code>srcdoc="<some markup />"</code> in <code>&lt;iframe/&gt;</code>.
+
+While the parser works for most use cases out-of-the-box, you may want to use
+something else. The parser is fully overrieable and allows for any string-based
+input, so long as it can be compiled to a tree structure.
 
 **Using with innerHTML:**
 
@@ -113,56 +118,12 @@ console.log(Internals.parse(`
 
 ## <a href="#options">Options</a>
 
-The parser is somewhat configurable, allowing you to opt into a strict-mode for
-erroring if invalid markup is passed. This could be useful to pair with the
-[HTML Linter Middleware](/middleware.html#html-linter).
+The parser is somewhat configurable, allowing you to change the list of self
+closing items. This could be useful to pair with the [HTML Linter
+Middleware](/middleware.html#html-linter).
 
-- [`strict`](#strict-mode) - Toggle strict mode parsing
-- [`rawElements`](#block-elements) - Modify the list of elements that have raw values
-- [`selfClosingElements`](#self-closing) - Modify the list of elements that can self close
-
-<a name="strict-mode"></a>
-
----
-
-### <a href="#strict-mode">Strict mode</a>
-
-By default the parser operates in loose-mode which is forgiving of missing
-closing tags, poor markup, and other common issues. When opting into strict
-mode you will receive errors if you don't properly self close tags, have
-mismatched tag names, etc.
-
-```js
-import { innerHTML } from 'diffhtml';
-
-const options = {
-  parser: {
-    strict: true,
-  }
-};
-
-// Will be fine since the elements match
-innerHTML(document.body, `
-  <h1>Hello world</h1>
-`, options);
-
-// Will throw since the elements do not match
-innerHTML(document.body, `
-  <h1>Hello world</h2>
-`, options);
-```
-
-Unlike the other two options below, this feature can be configured using the
-tagged template [`html`](/api.html#html) directly.
-
-```js
-import { html } from 'diffhtml';
-
-// Will throw an error due to the tag mismatch
-html.strict`
-  <p></div>
-`;
-```
+- [`rawElements`](#block-elements) - Modify the list of elements that have text values instead of markup
+- [`voidElements`](#self-closing) - Modify the list of elements that can self close
 
 <a name="block-elements"></a>
 

--- a/packages/diffhtml-website/public/styles/index.css
+++ b/packages/diffhtml-website/public/styles/index.css
@@ -3,11 +3,11 @@
 @import 'https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css';
 
 html, body {
+  width: 100%;
   max-height: 100%;
-  margin: 0 auto;
+  margin: 0;
   display: flex;
   font-family: Lato, Arial, Helvetica, sans-serif;
-  background: linear-gradient(to right, #F3F3F3 0%, #FCFDF0 calc(50% - 650px), #F3F3F3 50%, #F3F3F3 100%);
   touch-action: manipulation;
 }
 
@@ -53,7 +53,7 @@ pre code {
 
 layer#navigation {
   display: flex;
-  background-color: rgba(252, 253, 240, 1);
+  background-color: #fcffee;
   padding: 0 20px;
   padding-right: 0;
   width: 240px;
@@ -145,12 +145,12 @@ layer#navigation li.header h4 {
 
 layer#main {
   background-color: #FFF;
-  max-width: 960px;
   overflow-y: scroll;
   line-height: 30px;
   font-size: 18px;
   color: #333;
   box-sizing: border-box;
+  width: 100%;
 }
 
 layer#main header {
@@ -406,6 +406,12 @@ h1 a.github:hover {
   line-height: 280px;
 }
 
+/* Page content */
+div.page-content {
+  max-width: 960px;
+  margin: auto;
+}
+
 /* Tablet */
 @media only screen and (max-width : 760px) {
   html, body {
@@ -422,7 +428,7 @@ h1 a.github:hover {
   }
 
   body.open {
-    background: linear-gradient(to right, #333 248px, #F3F3F3 248px, #F3F3F3 100%);
+    background: #F3F3F3;
     user-select: none;
     overflow: hidden;
   }
@@ -430,6 +436,14 @@ h1 a.github:hover {
   nav {
     display: block;
     right: auto;
+  }
+
+  pre {
+    white-space: pre-wrap;
+    white-space: -moz-pre-wrap;
+    white-space: -pre-wrap;
+    white-space: -o-pre-wrap;
+    word-wrap: break-word;
   }
 
   center {
@@ -450,7 +464,6 @@ h1 a.github:hover {
   }
 
   body.open layer#navigation {
-    background-color: rgba(252, 253, 240, 0.9);
     transition: transform cubic-bezier(.17,.67,.83,.67) 140ms;
     transform: translate3d(0, 0, 0);
     padding: 0 18px;
@@ -497,7 +510,7 @@ h1 a.github:hover {
     text-align: left;
     margin-left: 0;
     padding-left: 0;
-    padding-top: 4px;
+    padding-top: 15px;
     padding-bottom: 0;
     display: inline-block;
     max-width: calc(100% - 55px);
@@ -557,7 +570,7 @@ h1 a.github:hover {
   .open-menu {
     display: inline-block;
     color: #333;
-    top: -5px;
+    top: -15px;
     padding: 10px 20px;
     cursor: pointer;
     z-index: 100;

--- a/packages/diffhtml/lib/node/create.js
+++ b/packages/diffhtml/lib/node/create.js
@@ -78,7 +78,10 @@ export default function createNode(vTreeLike, ownerDocument = globalThis.documen
   // Create empty text elements. They will get filled in during the patch
   // process.
   if (!domNode) {
-    if (nodeName === '#text') {
+    if (nodeName === '#comment') {
+      domNode = ownerDocument.createComment(vTree.nodeValue || EMPTY.STR);
+    }
+    else if (nodeName === '#text') {
       domNode = ownerDocument.createTextNode(vTree.nodeValue || EMPTY.STR);
     }
     // Support dynamically creating document fragments.

--- a/packages/diffhtml/lib/tasks/parse-new-tree.js
+++ b/packages/diffhtml/lib/tasks/parse-new-tree.js
@@ -12,7 +12,7 @@ export default function parseNewTree(transaction) {
   if (typeof input === 'string') {
     measure('parsing input for new tree');
 
-    const { childNodes } = Internals.parse(input, undefined, options);
+    const { childNodes } = Internals.parse(input, options);
     const vTree = createTree(childNodes);
 
     if (vTree) {

--- a/packages/diffhtml/lib/tree/create.js
+++ b/packages/diffhtml/lib/tree/create.js
@@ -159,8 +159,7 @@ export default function createTree(input, attributes, childNodes, ...rest) {
   }
 
   // Assume any remaining objects are VTree-like.
-  if (isObject) {
-
+  if (isObject && !attributes) {
     /** @type {VTreeLike} */
     const {
       rawNodeName,
@@ -219,6 +218,8 @@ export default function createTree(input, attributes, childNodes, ...rest) {
   entry.childNodes.length = 0;
   entry.attributes = {};
 
+  // Were childNodes passed as attributes? If so, use the attributes parameter
+  // instead.
   const useAttributes = isArray(attributes) || typeof attributes !== 'object';
   const useNodes = useAttributes ? attributes : childNodes;
   const allNodes = flatten(isArray(useNodes) ? useNodes : [useNodes]);

--- a/packages/diffhtml/lib/util/config.js
+++ b/packages/diffhtml/lib/util/config.js
@@ -16,7 +16,7 @@ export const globalConfig = {
  * @param {unknown} value
  * @param {string} type
  *
- * @returns {unknown}
+ * @return {unknown}
  */
 function formatValue(value, type) {
   const valueAsString = String(value);

--- a/packages/diffhtml/lib/util/symbols.js
+++ b/packages/diffhtml/lib/util/symbols.js
@@ -1,3 +1,2 @@
-export const $$strict = Symbol.for('diff.strict');
 export const $$insertAfter = Symbol.for('diff.after');
 export const $$diffHTML = Symbol.for('diffHTML');

--- a/packages/diffhtml/lib/util/types.js
+++ b/packages/diffhtml/lib/util/types.js
@@ -148,8 +148,6 @@ export const Middleware = EMPTY.OBJ;
 /**
  * @typedef {Object} ParserConfig
  *
- * @property {Boolean=} strict - Should the parser operate in strict mode
- * @property {Boolean=} trim - Trim surrounding whitespace nodes
  * @property {string[]=} rawElements - Set of raw element tagNames, empty is all
  * @property {string[]=} selfClosingElements - Set of self closing element tagNames, empty is all
  */

--- a/packages/diffhtml/test/html.js
+++ b/packages/diffhtml/test/html.js
@@ -1,12 +1,13 @@
+// @ts-nocheck
 import { equal, deepEqual, doesNotThrow, throws } from 'assert';
 import html from '../lib/html';
 import Internals from '../lib/util/internals';
 import parse from '../lib/util/parse';
 import createTree from '../lib/tree/create';
-import validateMemory from './util/validate-memory';
 import { NodeCache } from '../lib/util/types';
+import validateMemory from './util/validate-memory';
 
-describe('HTML (Tagged template)', function() {
+describe('HTML (Tagged template)', () => {
   beforeEach(() => {
     Internals.parse = parse;
   });
@@ -32,14 +33,14 @@ describe('HTML (Tagged template)', function() {
     equal(vTree.nodeName, 'div');
   });
 
-  it('will interpolate a single string value in an attribute', function() {
+  it('will interpolate a single string value in an attribute', () => {
     const foo = 'foo';
     const span = html`<span class="${foo}" />`;
 
     equal(span.attributes.class, 'foo');
   });
 
-  it('will interpolate multiple string values in an attribute', function() {
+  it('will interpolate multiple string values in an attribute', () => {
     const foo = 'foo';
     const bar = 'bar';
 
@@ -48,44 +49,70 @@ describe('HTML (Tagged template)', function() {
     equal(multipleValues.attributes.class, 'foo bar');
   });
 
-  it('will support invalid characters in attributes', function() {
-    const div = html`<div
-      @ns@key="value"
-      $ns$key="value"
-      #ns#key="value"
-    />`;
+  it('will support invalid characters in attributes', () => {
+    const div = html`
+      <div
+        @ns@key="value"
+        $ns$key="value"
+        #ns#key="value"
+      />
+    `;
 
     equal(div.attributes['@ns@key'], 'value');
     equal(div.attributes['$ns$key'], 'value');
     equal(div.attributes['#ns#key'], 'value');
   });
 
-  it('will support namespace attributes', function() {
+  it('will support namespace attributes', () => {
     const div = html`<div ns:key="value" />`;
 
     equal(div.attributes['ns:key'], 'value');
   });
 
-  it('will support dot attributes', function() {
+  it('will support dot attributes', () => {
     const div = html`<div ns.key="value" />`;
 
     equal(div.attributes['ns.key'], 'value');
   });
 
-  it('will interpolate value-less attributes', function() {
+  it('will interpolate static value-less attributes', () => {
+    const input = html`<input type="checkbox" checked>`;
+
+    equal(input.attributes.checked, true);
+  });
+
+  it('will interpolate dynamic value-less attributes', () => {
     const checked = 'checked';
     const input = html`<input type="checkbox" ${checked}>`;
 
     equal(input.attributes.checked, true);
   });
 
-  it('will interpolate multiple type values in an attribute', function() {
+  it('will interpolate multiple value-less attributes', () => {
+    const checked = 'checked';
+    const disabled = 'disabled'
+    const input = html`<input type="checkbox" ${checked} ${disabled}>`;
+
+    equal(input.attributes.checked, true);
+    equal(input.attributes.disabled, true);
+  });
+
+  it('will interpolate multiple type values in an attribute', () => {
     const foo = 'foo';
     const bar = {};
 
     const multipleValues = html`<span class="${foo} ${bar}" />`;
 
     equal(multipleValues.attributes.class, 'foo [object Object]');
+  });
+
+  it('will interpolate multiple type values in an attribute with toString', () => {
+    const foo = 'foo';
+    const bar = { toString() { return 'replacement'; } };
+
+    const multipleValues = html`<span class="${foo} ${bar}" />`;
+
+    equal(multipleValues.attributes.class, 'foo replacement');
   });
 
   it('will interpolate attribute values with text', () => {
@@ -244,7 +271,7 @@ describe('HTML (Tagged template)', function() {
     });
   });
 
-  it('will support aligning attributes on new lines', function() {
+  it('will support aligning attributes on new lines', () => {
     const multipleValues = html`
       <span class="
         ${'foo'}
@@ -269,7 +296,7 @@ describe('HTML (Tagged template)', function() {
     });
   });
 
-  it('will interpolate a string child', function() {
+  it('will interpolate a string child', () => {
     const span = html`<span>${'foo'}</span>`;
 
     deepEqual(span.childNodes[0], {
@@ -283,7 +310,7 @@ describe('HTML (Tagged template)', function() {
     });
   });
 
-  it('will interpolate a string child with html entities', function() {
+  it('will interpolate a string child with html entities', () => {
     const span = html`<span>${'&infin;'}</span>`;
 
     deepEqual(span.childNodes[0], {
@@ -297,7 +324,7 @@ describe('HTML (Tagged template)', function() {
     });
   });
 
-  it('will interpolate a VTree child', function() {
+  it('will interpolate a VTree child', () => {
     const span = html`<span>${createTree('#text', 'foo')}</span>`;
 
     deepEqual(span.childNodes[0], {
@@ -318,7 +345,7 @@ describe('HTML (Tagged template)', function() {
     equal(NodeCache.get(vTree), domNode);
   });
 
-  it('will interpolate a Text Node', function() {
+  it('will interpolate a Text Node', () => {
     const textNode = document.createTextNode('foo');
     const span = html`<span>${textNode}</span>`;
     const vTree = createTree(textNode);
@@ -327,7 +354,7 @@ describe('HTML (Tagged template)', function() {
     equal(NodeCache.get(vTree), textNode);
   });
 
-  it('will interpolate a DOM Node', function() {
+  it('will interpolate a DOM Node', () => {
     const domNode = document.createElement('div');
     const span = html`<span>${domNode}</span>`;
     const vTree = createTree(domNode);
@@ -345,7 +372,7 @@ describe('HTML (Tagged template)', function() {
     equal(NodeCache.get(vTree), domNode);
   });
 
-  it('will interpolate an array of children', function() {
+  it('will interpolate an array of children', () => {
     const fixture = [createTree('#text', 'foo'), createTree('#text', 'bar')];
     const span = html`<span>${fixture}</span>`;
 
@@ -381,21 +408,38 @@ describe('HTML (Tagged template)', function() {
     const span = html`<!--<span>${fixtures[0]}</span>--><span>${fixtures[1]}</span>`;
 
     deepEqual(span, {
-      rawNodeName: 'span',
-      nodeName: 'span',
-      nodeType: 1,
-      nodeValue: '',
-      key: '',
+      rawNodeName: '#document-fragment',
+      nodeName: '#document-fragment',
       attributes: {},
+      nodeValue: '',
+      nodeType: 11,
+      key: '',
+
       childNodes: [{
-        rawNodeName: '#text',
-        nodeName: '#text',
-        nodeType: 3,
-        nodeValue: 'this',
+        rawNodeName: '#comment',
+        nodeName: '#comment',
+        nodeValue: '<span>test</span>',
+        nodeType: 8,
+        key: '',
+        childNodes: [],
+        attributes: {},
+      }, {
+        rawNodeName: 'span',
+        nodeName: 'span',
+        nodeType: 1,
+        nodeValue: '',
         key: '',
         attributes: {},
-        childNodes: [],
-      }],
+        childNodes: [{
+          rawNodeName: '#text',
+          nodeName: '#text',
+          nodeType: 3,
+          nodeValue: 'this',
+          key: '',
+          attributes: {},
+          childNodes: [],
+        }],
+      }]
     });
   });
 
@@ -500,120 +544,5 @@ describe('HTML (Tagged template)', function() {
     equal(vTree.childNodes[0].childNodes.length, 1);
     equal(vTree.childNodes[0].childNodes[0].nodeName, '#text');
     equal(vTree.childNodes[0].childNodes[0].nodeValue, 'inner');
-  });
-
-  describe('Strict mode', () => {
-    it('will clean up after an error', () => {
-      throws(() => html.strict`
-        <web-component>
-      `, /Possibly invalid markup. <web-component> must be closed in strict mode/);
-
-      // Test a second time to ensure clean up occured before the failure.
-      throws(() => html.strict`
-        <web-component>
-      `, /Possibly invalid markup. <web-component> must be closed in strict mode/);
-    });
-
-    it('will error if tags cannot self-close', () => {
-      throws(() => html.strict`
-        <web-component>
-      `, /Possibly invalid markup. <web-component> must be closed in strict mode/);
-    });
-
-    it('will error if the closing tag does not match', () => {
-      throws(() => html.strict`
-        <web-component></not-component>
-      `, /Possibly invalid markup. <web-component> must be closed in strict mode/);
-    });
-
-    it('will error if tag is not closed', () => {
-      throws(() => html.strict`
-        <web-component
-      `, /Possibly invalid markup. Opening tag was not properly closed/);
-    });
-
-    it('will error if tag is not closed along with proper markup', () => {
-      throws(() => html.strict`
-        <proper></proper>
-        <web-component
-      `, /Possibly invalid markup. Opening tag was not properly closed/);
-
-      throws(() => html.strict`
-        <web-component
-        <proper></proper>
-      `, /Possibly invalid markup. <web-component> must be closed in strict mode/);
-
-      throws(() => html.strict`
-        <proper></proper>
-        <web-component
-        <proper></proper>
-      `, /Possibly invalid markup. <web-component> must be closed in strict mode/);
-    });
-
-    it('will error if tag is not opened', () => {
-      throws(() => html.strict`
-        web-component>
-      `, /Possibly invalid markup. Opening tag was not properly opened/);
-    });
-
-    it('will error when a custom component is not closed', () => {
-      const Component = () => {};
-
-      throws(() => html.strict`
-        <${Component}>
-      `, /Possibly invalid markup. <Component> must be closed in strict mode/);
-    });
-
-    it('will not error on doctype', () => {
-      doesNotThrow(() => html.strict`
-        <!doctype>
-        <html></html>
-      `);
-
-      const actual = html.strict`<!doctype>
-        <html></html>`;
-
-      deepEqual(actual, {
-        rawNodeName: 'html',
-        nodeName: 'html',
-        nodeValue: '',
-        nodeType: 1,
-        key: '',
-        childNodes:
-         [ { rawNodeName: 'head',
-             nodeName: 'head',
-             nodeValue: '',
-             nodeType: 1,
-             key: '',
-             childNodes: [],
-             attributes: {} },
-           { rawNodeName: 'body',
-             nodeName: 'body',
-             nodeValue: '',
-             nodeType: 1,
-             key: '',
-             childNodes: [],
-             attributes: {} } ],
-        attributes: {}
-      });
-    });
-
-    it('will error if tag is not opened along with proper markup', () => {
-      throws(() => html.strict`
-        <proper></proper>
-        web-component>
-      `, /Possibly invalid markup. Opening tag was not properly opened./);
-
-      //throws(() => html.strict`
-      //  web-component>
-      //  <proper></proper>
-      //`, /Possibly invalid markup. <web-component> must be closed in strict mode/);
-
-      //throws(() => html.strict`
-      //  <proper></proper>
-      //  web-component>
-      //  <proper></proper>
-      //`, /Possibly invalid markup. <web-component> must be closed in strict mode/);
-    });
   });
 });

--- a/packages/diffhtml/test/integration/basics.js
+++ b/packages/diffhtml/test/integration/basics.js
@@ -166,10 +166,10 @@ describe('Integration: Basics', function() {
       });
     });
 
-    it('will error if arrays are attempted to be spread in strict mode', function() {
+    it('will error when arrays are spread since they are invalid', function() {
       const obj = [1, false];
 
-      assert.throws(() => diff.html.strict`
+      assert.throws(() => diff.html`
         <div
           class="test"
           ${obj}

--- a/packages/diffhtml/test/integration/inner.js
+++ b/packages/diffhtml/test/integration/inner.js
@@ -175,9 +175,7 @@ describe('Integration: innerHTML', function() {
       <div></div>
     `);
 
-    assert.equal(this.fixture.outerHTML, `<div>
-      <div></div>
-    </div>`);
+    assert.equal(this.fixture.outerHTML, `<div><div></div></div>`);
 
     diff.innerHTML(this.fixture, html`
       <h1></h1>
@@ -359,10 +357,10 @@ describe('Integration: innerHTML', function() {
   });
 
   describe('Comments', function() {
-    it('ignores comments', function() {
+    it('supports comments', function() {
       diff.innerHTML(this.fixture, '<div><p><!-- test --></p></div>');
 
-      assert.equal(this.fixture.firstChild.innerHTML, '<p></p>');
+      assert.equal(this.fixture.firstChild.innerHTML, '<p><!-- test --></p>');
     });
   });
 

--- a/packages/diffhtml/test/integration/outer.js
+++ b/packages/diffhtml/test/integration/outer.js
@@ -151,10 +151,10 @@ describe('Integration: outerHTML', function() {
   });
 
   describe('Comments', function() {
-    it('ignores comments', function() {
+    it('does not ignore comments', function() {
       diff.outerHTML(this.fixture, '<div><p><!-- test --></p></div>');
 
-      strictEqual(this.fixture.innerHTML, '<p></p>');
+      strictEqual(this.fixture.innerHTML, '<p><!-- test --></p>');
     });
   });
 

--- a/packages/diffhtml/test/integration/tagged-template.js
+++ b/packages/diffhtml/test/integration/tagged-template.js
@@ -254,4 +254,21 @@ describe('Integration: Tagged template', function() {
 
     assert.equal(this.fixture.childNodes[1].checked, false);
   });
+
+  it('can parse a comment with html in it', function() {
+    const className = 'test';
+
+    diff.innerHTML(this.fixture, html`
+      <!--
+      <input
+        class=${className}
+      />
+      -->
+    `);
+
+    assert.strictEqual(this.fixture.childNodes[1].nodeName, '#comment');
+    assert.strictEqual(this.fixture.childNodes[1].nodeValue.trim(), `<input
+        class=test
+      />`);
+  });
 });

--- a/packages/diffhtml/test/to-string.js
+++ b/packages/diffhtml/test/to-string.js
@@ -21,21 +21,6 @@ describe('toString', function() {
     strictEqual(actual, expected);
   });
 
-  it('can support strict html parsing, throwing on error', () => {
-    throws(() => {
-      toString('<p>Hello world', { parser: { strict: true } });
-    }, {
-      name: 'Error',
-      message: `
-
-<p>Hello world
- ^
-    Possibly invalid markup. <p> must be closed in strict mode.
-            `
-    });
-
-  });
-
   it('can render simple vTree', () => {
     const actual = toString(html`<div>Hello world</div>`);
     const expected = `<div>Hello world</div>`;

--- a/packages/diffhtml/test/use.js
+++ b/packages/diffhtml/test/use.js
@@ -96,7 +96,7 @@ describe('Use (Middleware)', function() {
     `);
 
     equal(domNode.innerHTML.trim(), '<span></span>');
-    equal(domNode.childNodes[1], span);
+    equal(domNode.childNodes[0], span);
 
     release(domNode);
   });
@@ -108,10 +108,6 @@ describe('Use (Middleware)', function() {
     let i = 0;
 
     this.createTreeHook = ({ rawNodeName, attributes }) => {
-      if (i === 4) {
-        return;
-      }
-
       if (typeof rawNodeName === 'function') {
         i++;
         return rawNodeName(attributes);


### PR DESCRIPTION
**Status:** In Progress

**Goals:**

The primary motivations of the rewrite are to fix known compatibility bugs, support comments completely (instead of skipping them), improve support for middleware, and greatly improve memory usage and performance. The way the new parser works is by breaking down the HTML using global regexes that have their lastIndex reset on each loop. No copies or references of the input HTML are made. The VTree hierarchy is built up as the markup is crawled. This iteration of the parser is to help ship 1.0. Using regex's like this is prone to errors and not ideal to parse real HTML, but using any known alternatives will incur significant filesize impact, not work in Node, or be overkill for what is needed, which is basically HTML/XML/SVG -> JSON.

**Tasks:**

- [x] Extract each regex into a separate module and perform isolated tests on each using partial fragments of markup
- [x] Remove/deprecate strict mode
- [x] Get all existing unit tests passing

**Future tasks:**

- [ ] Implement any changes needed to fully support the HTMLHint plugin
- [ ] Code cleanup
- [ ] Add more tests
- [ ] Write documentation