### PR TITLE
Call createTree on parser close, not open

### DIFF
--- a/packages/diffhtml/lib/util/parse.js
+++ b/packages/diffhtml/lib/util/parse.js
@@ -158,7 +158,10 @@ export default function parse(html, options = {}) {
   // Cursor into the markup that we use when parsing.
   let i = 0;
 
-  // The active element being crawled.
+  /**
+   * The active element being crawled.
+   * @type {VTree}
+   */
   let pointer = root;
 
   // The pointer is open when looking for attributes, self closing, or open
@@ -271,9 +274,13 @@ export default function parse(html, options = {}) {
       // completed element. So create a fake VTree, to build up the object
       // until we have attributes and child nodes.
       const newTree = {
+        rawNodeName: tagName,
         nodeName: tagName,
         childNodes: [],
         attributes: {},
+        nodeType: EMPTY.NUM,
+        nodeValue: EMPTY.STR,
+        key: EMPTY.STR,
       };
       const supportsEndTagOmission = endTagOmissionRules[tagName];
 

--- a/packages/diffhtml/lib/util/parse.js
+++ b/packages/diffhtml/lib/util/parse.js
@@ -271,7 +271,6 @@ export default function parse(html, options = {}) {
       // completed element. So create a fake VTree, to build up the object
       // until we have attributes and child nodes.
       const newTree = {
-        rawNodeName: tagName,
         nodeName: tagName,
         childNodes: [],
         attributes: {},

--- a/packages/diffhtml/lib/util/parse.js
+++ b/packages/diffhtml/lib/util/parse.js
@@ -172,13 +172,14 @@ export default function parse(html, options = {}) {
   let lastCommentIndex = html.indexOf('<!--');
 
   // Closes the current element and calls createTree to allow middleware to tap
-  // into it. Resets the pointer to the parent.
+  // into it. Resets the pointer to the parent. This function should never be
+  // called with the root element, otherwise it will set a null pointer.
   const resetPointer = () => {
     // Create tree is called to normalize the stack into VTree and allow
     // middleware to hook into the parser.
     const newTree = createTree(stack.pop());
 
-    // Create the tree once closed.
+    // Reset the pointer to the parent.
     pointer = stack[stack.length - 1];
     pointer.childNodes.push(newTree);
   };

--- a/packages/diffhtml/test/use.js
+++ b/packages/diffhtml/test/use.js
@@ -105,11 +105,8 @@ describe('Use (Middleware)', function() {
     const Fn = ({ message }) => html`<marquee>${message}</marquee>`;
     const domNode = document.createElement('div');
 
-    let i = 0;
-
     this.createTreeHook = ({ rawNodeName, attributes }) => {
       if (typeof rawNodeName === 'function') {
-        i++;
         return rawNodeName(attributes);
       }
     };
@@ -122,6 +119,45 @@ describe('Use (Middleware)', function() {
       <marquee>Hello world</marquee>
     </div>`);
 
+    release(domNode);
+  });
+
+  it('will allow access to attributes during create', () => {
+    const domNode = document.createElement('div');
+
+    let message = null;
+
+    this.createTreeHook = ({ nodeName, attributes }) => {
+      if (nodeName === 'div' && attributes.message) {
+        message = attributes.message;
+      }
+    };
+
+    innerHTML(domNode, html`
+      <div message="Hello world" />
+    `);
+
+    equal(message, 'Hello world');
+    release(domNode);
+  });
+
+  it('will allow access to childNodes during create', () => {
+    const domNode = document.createElement('div');
+
+    let message = null;
+
+    this.createTreeHook = ({ nodeName, childNodes }) => {
+      if (nodeName === 'p') {
+        // Access the parsed childNodes
+        message = childNodes[0].attributes.message;
+      }
+    };
+
+    innerHTML(domNode, html`
+      <p><div message="Hello world" /></p>
+    `);
+
+    equal(message, 'Hello world');
     release(domNode);
   });
 


### PR DESCRIPTION
In the new parser createTree was called with only a tag name and not the attributes or childNodes. This PR fixes the new parser to wait until the element is closed before calling createTree. This work uncovered some inconsistencies and improved the parser by closing out the pointer and resetting to the parent in a function.