### PR TITLE
Removes type aliases

### DIFF
--- a/packages/diffhtml/lib/html.js
+++ b/packages/diffhtml/lib/html.js
@@ -1,9 +1,13 @@
+/**
+ * @typedef {import('./util/types').VTree} VTree
+ * @typedef {import('./util/types').Supplemental} Supplemental
+ */
 import createTree from './tree/create';
 import Internals from './util/internals';
 import escape from './util/escape';
 import decodeEntities from './util/decode-entities';
 import internalProcess from './util/process';
-import { EMPTY, VTree, Supplemental, NODE_TYPE } from './util/types';
+import { EMPTY, NODE_TYPE } from './util/types';
 
 // Magic token used for interpolation.
 const TOKEN = '__DIFFHTML__';

--- a/packages/diffhtml/lib/inner-html.js
+++ b/packages/diffhtml/lib/inner-html.js
@@ -1,5 +1,10 @@
+/**
+ * @typedef {import('./util/types').ValidInput} ValidInput
+ * @typedef {import('./util/types').TransactionConfig} TransactionConfig
+ * @typedef {import('./util/types').Mount} Mount
+ */
 import Transaction, { defaultTasks } from './transaction';
-import { EMPTY, ValidInput, TransactionConfig, Mount } from './util/types';
+import { EMPTY } from './util/types';
 
 /**
  *

--- a/packages/diffhtml/lib/node/create.js
+++ b/packages/diffhtml/lib/node/create.js
@@ -1,13 +1,11 @@
+/**
+ * @typedef {import('../util/types').VTreeLike} VTreeLike
+ * @typedef {import('../util/types').VTree} VTree
+ * @typedef {import('../util/types').ValidNode} ValidNode
+ */
 import internalProcess from '../util/process';
 import globalThis from '../util/global';
-import {
-  NodeCache,
-  CreateNodeHookCache,
-  VTreeLike,
-  VTree,
-  ValidNode,
-  EMPTY,
-} from '../util/types';
+import { NodeCache, CreateNodeHookCache, EMPTY } from '../util/types';
 import createTree from '../tree/create';
 
 const namespace = 'http://www.w3.org/2000/svg';

--- a/packages/diffhtml/lib/node/patch.js
+++ b/packages/diffhtml/lib/node/patch.js
@@ -1,14 +1,12 @@
+/**
+ * @typedef {import('../util/types').ValidNode} ValidNode
+ * @typedef {import('../util/types').VTree} VTree
+ * @typedef {import('../util/types').TransactionState} TransactionState
+ */
 import createNode from './create';
 import { protectVTree, unprotectVTree } from '../util/memory';
 import decodeEntities from '../util/decode-entities';
-import {
-  PATCH_TYPE,
-  ValidNode,
-  VTree,
-  EMPTY,
-  TransactionState,
-  NodeCache,
-} from '../util/types';
+import { PATCH_TYPE, EMPTY, NodeCache } from '../util/types';
 import { $$insertAfter } from '../util/symbols';
 
 const { keys } = Object;

--- a/packages/diffhtml/lib/outer-html.js
+++ b/packages/diffhtml/lib/outer-html.js
@@ -1,5 +1,10 @@
+/**
+ * @typedef {import('./util/types').ValidInput} ValidInput
+ * @typedef {import('./util/types').TransactionConfig} TransactionConfig
+ * @typedef {import('./util/types').Mount} Mount
+ */
 import Transaction, { defaultTasks } from './transaction';
-import { EMPTY, ValidInput, TransactionConfig, Mount } from './util/types';
+import { EMPTY } from './util/types';
 
 /**
  * @param {Mount} mount

--- a/packages/diffhtml/lib/release.js
+++ b/packages/diffhtml/lib/release.js
@@ -1,5 +1,8 @@
+/**
+ * @typedef {import('./util/types').Mount} Mount
+ */
 import { gc, unprotectVTree } from './util/memory';
-import { StateCache, NodeCache, ReleaseHookCache, Mount } from './util/types';
+import { StateCache, NodeCache, ReleaseHookCache } from './util/types';
 
 // Supports the idle callback API. NodeJS does not, so we'll use setTimeout
 // there instead.

--- a/packages/diffhtml/lib/tasks/end-as-transaction.js
+++ b/packages/diffhtml/lib/tasks/end-as-transaction.js
@@ -1,4 +1,6 @@
-import Transaction from '../transaction';
+/**
+ * @typedef {import('../transaction').default} Transaction
+ */
 
 /**
  * End flow, this terminates the transaction and returns itself when completed.

--- a/packages/diffhtml/lib/tasks/parse-new-tree.js
+++ b/packages/diffhtml/lib/tasks/parse-new-tree.js
@@ -1,6 +1,8 @@
+/**
+ * @typedef {import('../transaction').default} Transaction
+ */
 import Internals from '../util/internals';
 import createTree from '../tree/create';
-import Transaction from '../transaction';
 
 /**
  * @param {Transaction} transaction

--- a/packages/diffhtml/lib/tasks/patch-node.js
+++ b/packages/diffhtml/lib/tasks/patch-node.js
@@ -1,6 +1,9 @@
+/**
+ * @typedef {import('../transaction').default} Transaction
+ * @typedef {import('../util/types').VTree} VTree
+ */
 import patch from '../node/patch';
-import Transaction from '../transaction';
-import { CreateNodeHookCache, VTree } from '../util/types';
+import { CreateNodeHookCache } from '../util/types';
 import globalThis from '../util/global';
 
 /**

--- a/packages/diffhtml/lib/tasks/reconcile-trees.js
+++ b/packages/diffhtml/lib/tasks/reconcile-trees.js
@@ -1,7 +1,10 @@
-import { StateCache, NODE_TYPE, VTree } from '../util/types';
+/**
+ * @typedef {import('../transaction').default} Transaction
+ * @typedef {import('../util/types').VTree} VTree
+ */
+import { StateCache, NODE_TYPE } from '../util/types';
 import { protectVTree } from '../util/memory';
 import createTree from '../tree/create';
-import Transaction from '../transaction';
 import release from '../release';
 
 /**

--- a/packages/diffhtml/lib/tasks/should-update.js
+++ b/packages/diffhtml/lib/tasks/should-update.js
@@ -1,4 +1,6 @@
-import Transaction from '../transaction';
+/**
+ * @typedef {import('../transaction').default} Transaction
+ */
 
 /**
  * Allows the transaction to terminate early if no contents have changed.

--- a/packages/diffhtml/lib/tasks/sync-trees.js
+++ b/packages/diffhtml/lib/tasks/sync-trees.js
@@ -1,8 +1,11 @@
+/**
+ * @typedef {import('../util/types').Mount} Mount
+ * @typedef {import('../transaction').default} Transaction
+ */
 import syncTree from '../tree/sync';
 import createNode from '../node/create';
-import { StateCache, NODE_TYPE, PATCH_TYPE, EMPTY, Mount } from '../util/types';
+import { StateCache, NODE_TYPE, PATCH_TYPE, EMPTY } from '../util/types';
 import internalProcess from '../util/process';
-import Transaction from '../transaction';
 
 export default function syncTrees(/** @type {Transaction} */ transaction) {
   const { state, state: { measure }, oldTree, newTree, mount } = transaction;

--- a/packages/diffhtml/lib/to-string.js
+++ b/packages/diffhtml/lib/to-string.js
@@ -1,5 +1,10 @@
+/**
+ * @typedef {import('./util/types').ValidInput} ValidInput
+ * @typedef {import('./util/types').TransactionConfig} TransactionConfig
+ * @typedef {import('./util/types').VTree} VTree
+ * @typedef {import('./util/types').VTreeAttributes} VTreeAttributes
+ */
 import createTree from './tree/create';
-import { TransactionConfig, ValidInput, VTree, VTreeAttributes } from './util/types';
 import Transaction, { defaultTasks, tasks } from './transaction';
 import release from './release';
 

--- a/packages/diffhtml/lib/transaction.js
+++ b/packages/diffhtml/lib/transaction.js
@@ -1,14 +1,11 @@
-import {
-  MiddlewareCache,
-  StateCache,
-  NodeCache,
-  VTree,
-  ValidInput,
-  Mount,
-  TransactionConfig,
-  TransactionState,
-  EMPTY,
-} from './util/types';
+/**
+ * @typedef {import('./util/types').ValidInput} ValidInput
+ * @typedef {import('./util/types').TransactionConfig} TransactionConfig
+ * @typedef {import('./util/types').TransactionState} TransactionState
+ * @typedef {import('./util/types').VTree} VTree
+ * @typedef {import('./util/types').Mount} Mount
+ */
+import { MiddlewareCache, StateCache, NodeCache, EMPTY } from './util/types';
 import makeMeasure from './util/make-measure';
 import internalProcess from './util/process';
 import { protectVTree } from './util/memory';

--- a/packages/diffhtml/lib/tree/create.js
+++ b/packages/diffhtml/lib/tree/create.js
@@ -1,8 +1,10 @@
+/**
+ * @typedef {import('../util/types').ValidInput} ValidInput
+ * @typedef {import('../util/types').VTree} VTree
+ * @typedef {import('../util/types').VTreeLike} VTreeLike
+ */
 import Pool from '../util/pool';
 import {
-  VTree,
-  VTreeLike,
-  ValidInput,
   EMPTY,
   NODE_TYPE,
   NodeCache,

--- a/packages/diffhtml/lib/tree/sync.js
+++ b/packages/diffhtml/lib/tree/sync.js
@@ -1,11 +1,13 @@
-import Transaction from '../transaction';
+/**
+ * @typedef {import('../util/types').TransactionState} TransactionState
+ * @typedef {import('../util/types').VTree} VTree
+ * @typedef {import('../transaction').default} Transaction
+ */
 import internalProcess from '../util/process';
 import {
   SyncTreeHookCache,
-  TransactionState,
   PATCH_TYPE,
   NODE_TYPE,
-  VTree,
   EMPTY,
 } from '../util/types';
 

--- a/packages/diffhtml/lib/use.js
+++ b/packages/diffhtml/lib/use.js
@@ -1,3 +1,6 @@
+/**
+ * @typedef {import('./util/types').Middleware} Middleware
+ */
 import {
   MiddlewareCache,
   CreateTreeHookCache,
@@ -5,7 +8,6 @@ import {
   SyncTreeHookCache,
   ReleaseHookCache,
   ParseHookCache,
-  Middleware,
 } from './util/types';
 import internalProcess from './util/process';
 import Internals from './util/internals';

--- a/packages/diffhtml/lib/util/config.js
+++ b/packages/diffhtml/lib/util/config.js
@@ -1,10 +1,13 @@
+/**
+ * @typedef {import('./types').Config} Config
+ */
 import internalProcess from './process';
 import globalThis from './global';
 
 const { parseInt } = Number;
 const { parse } = JSON;
 
-/** @type {import('./types').Config} */
+/** @type {Config} */
 export const globalConfig = {
   collectMetrics: true,
   executeScripts: true,

--- a/packages/diffhtml/lib/util/internals.js
+++ b/packages/diffhtml/lib/util/internals.js
@@ -1,3 +1,6 @@
+/**
+ * @typedef {import('./types').Internals} Internals
+ */
 import Transaction, { defaultTasks, tasks } from '../transaction';
 import createNode from '../node/create';
 import syncTree from '../tree/sync';
@@ -12,7 +15,6 @@ import {
   EMPTY,
   PATCH_TYPE,
   NODE_TYPE,
-  Internals,
   StateCache,
   NodeCache,
   MiddlewareCache,

--- a/packages/diffhtml/lib/util/parse.js
+++ b/packages/diffhtml/lib/util/parse.js
@@ -1,12 +1,11 @@
+/**
+ * @typedef {import('./types').TransactionConfig} TransactionConfig
+ * @typedef {import('./types').ParserConfig} ParserConfig
+ * @typedef {import('./types').VTree} VTree
+ */
 import createTree from '../tree/create';
 import getConfig from './config';
-import {
-  NODE_TYPE,
-  EMPTY,
-  TransactionConfig,
-  VTree,
-  ParserConfig,
-} from './types';
+import { NODE_TYPE, EMPTY } from './types';
 
 const rawElementsDefaults = [
   'script',

--- a/packages/diffhtml/lib/util/pool.js
+++ b/packages/diffhtml/lib/util/pool.js
@@ -1,4 +1,7 @@
-import { EMPTY, NODE_TYPE, VTree } from './types';
+/**
+ * @typedef {import('./types').VTree} VTree
+ */
+import { EMPTY, NODE_TYPE } from './types';
 import getConfig from './config';
 
 const size = /** @type {Number} */ (getConfig('initialPoolSize', 5000));

--- a/packages/diffhtml/lib/util/process.js
+++ b/packages/diffhtml/lib/util/process.js
@@ -1,4 +1,7 @@
+/**
+ * @typedef {import('./types').Config} Config
+ */
 export default typeof process !== 'undefined' ? process : {
-  env: /** @type {import('./types').Config} */({ NODE_ENV: 'development' }),
+  env: /** @type {Config} */({ NODE_ENV: 'development' }),
   argv: /** @type {string[]} */ ([]),
 };

--- a/packages/diffhtml/lib/util/types.js
+++ b/packages/diffhtml/lib/util/types.js
@@ -99,7 +99,6 @@ export const VTreeAttributes = EMPTY.OBJ;
  * @property {VTree[]} childNodes - Any nested elements
  * @property {VTreeAttributes} attributes - Any key/val attributes for the Node
  */
-export const VTree = EMPTY.OBJ;
 
 /**
  * @typedef {Object} VTreeLike
@@ -114,22 +113,18 @@ export const VTree = EMPTY.OBJ;
  * @property {VTreeLike[]=} children - Any nested elements
  * @property {any=} attributes - Any key/val attributes for the Node
  */
-export const VTreeLike = EMPTY.OBJ;
 
 /**
  * @typedef {HTMLElement | ChildNode | Element | Text | Comment | DocumentFragment | Function | string | string[] | VTree | VTree[] | VTreeLike | VTreeLike[]} ValidInput
  */
-export const ValidInput = EMPTY.OBJ;
 
 /**
  * @typedef {Element | HTMLElement | Text | DocumentFragment | ChildNode} ValidNode
  */
-export const ValidNode = EMPTY.OBJ;
 
 /**
  * @typedef {ValidNode | VTree | VTree[] | VTreeLike | VTreeLike[]} Mount
  */
-export const Mount = EMPTY.OBJ;
 
 /**
  * @typedef {Object} Middleware
@@ -143,7 +138,6 @@ export const Mount = EMPTY.OBJ;
  * @property {Function=} releaseHook
  * @property {Function=} parseHook
  */
-export const Middleware = EMPTY.OBJ;
 
 /**
  * @typedef {Object} ParserConfig
@@ -151,7 +145,6 @@ export const Middleware = EMPTY.OBJ;
  * @property {string[]=} rawElements - Set of raw element tagNames, empty is all
  * @property {string[]=} selfClosingElements - Set of self closing element tagNames, empty is all
  */
-export const ParserConfig = EMPTY.OBJ;
 
 /**
  * @typedef {Object} TransactionConfig
@@ -162,7 +155,6 @@ export const ParserConfig = EMPTY.OBJ;
  * @property {ParserConfig=} parser - override parser options
  * @property {Boolean=} disableMutationObserver - to disable mutation observer (enabled by default if available)
  */
-export const TransactionConfig = EMPTY.OBJ;
 
 /**
  * @typedef {Object} GlobalConfig
@@ -170,12 +162,10 @@ export const TransactionConfig = EMPTY.OBJ;
  * @property {string=} NODE_ENV - To set the runtime execution mode
  * @property {Boolean=} collectMetrics - to collect performance metrics, defaults to false
  */
-export const GlobalConfig = EMPTY.OBJ;
 
 /**
  * @typedef {TransactionConfig & GlobalConfig & { [key: string]: unknown }} Config
  */
-export const Config = {};
 
 /**
  * @typedef {Object} Supplemental
@@ -184,7 +174,6 @@ export const Config = {};
  * @property {{ [key: string]: any }} attributes
  * @property {{ [key: string]: any }} children
  */
-export const Supplemental = EMPTY.OBJ;
 
 /**
  * @typedef {Object} TransactionState
@@ -198,7 +187,6 @@ export const Supplemental = EMPTY.OBJ;
  * @property {MutationObserver=} mutationObserver
  * @property {Document=} ownerDocument
 */
-export const TransactionState = EMPTY.OBJ;
 
 /**
  * @typedef {Object} Internals
@@ -227,4 +215,3 @@ export const TransactionState = EMPTY.OBJ;
  * @property {ReleaseHookCache} ReleaseHookCache
  * @property {ParseHookCache} ParseHookCache
  */
-export const Internals = EMPTY.OBJ;

--- a/packages/diffhtml/test/util/create-supplemental.js
+++ b/packages/diffhtml/test/util/create-supplemental.js
@@ -1,4 +1,6 @@
-import { Supplemental } from '../../lib/util/types';
+/**
+ * @typedef {import('../../lib/util/types').Supplemental} Supplemental
+ */
 
 /**
  * Converts a partial Supplemental object to a full Supplemental object.


### PR DESCRIPTION
By aliases objects to types we were able to use native ESM to get type access. Since the type system has zero runtime benefit, I've migrated all imports into JSDoc import comments and assigned local typedefs into each module scope.

This gets rid of circular dependency warnings and should be easier to read.