### PR TITLE
Fix for mutation observer isDirty

### DIFF
--- a/packages/diffhtml/lib/tasks/patch-node.js
+++ b/packages/diffhtml/lib/tasks/patch-node.js
@@ -3,7 +3,7 @@
  * @typedef {import('../util/types').VTree} VTree
  */
 import patch from '../node/patch';
-import { StateCache, CreateNodeHookCache } from '../util/types';
+import { CreateNodeHookCache } from '../util/types';
 import globalThis from '../util/global';
 
 /**

--- a/packages/diffhtml/lib/tasks/patch-node.js
+++ b/packages/diffhtml/lib/tasks/patch-node.js
@@ -3,7 +3,7 @@
  * @typedef {import('../util/types').VTree} VTree
  */
 import patch from '../node/patch';
-import { CreateNodeHookCache } from '../util/types';
+import { StateCache, CreateNodeHookCache } from '../util/types';
 import globalThis from '../util/global';
 
 /**
@@ -14,18 +14,13 @@ import globalThis from '../util/global';
  */
 export default function patchNode(transaction) {
   const { mount, state, patches } = transaction;
-  const { mutationObserver, measure, scriptsToExecute } = state;
+  const { measure, scriptsToExecute } = state;
 
   measure('patch node');
 
   const { ownerDocument } = /** @type {HTMLElement} */ (mount);
 
   state.ownerDocument = ownerDocument || globalThis.document;
-
-  // Always disconnect a MutationObserver before patching.
-  if (mutationObserver) {
-    mutationObserver.disconnect();
-  }
 
   // Hook into the Node creation process to find all script tags, and mark them
   // for execution.

--- a/packages/diffhtml/lib/transaction.js
+++ b/packages/diffhtml/lib/transaction.js
@@ -215,6 +215,14 @@ export default class Transaction {
     state.isRendering = false;
     state.isDirty = false;
 
+    // After a transaction ends, clear out all mutation observer's to avoid
+    // issues where parent components are triggered from child renders.
+    StateCache.forEach(state => {
+      if (state.mutationObserver) {
+        state.mutationObserver.takeRecords();
+      }
+    });
+
     // If MutationObserver is available, look for changes.
     if (mountAsHTMLEl.ownerDocument && mutationObserver) {
       mutationObserver.observe(mountAsHTMLEl, {

--- a/packages/diffhtml/lib/transaction.js
+++ b/packages/diffhtml/lib/transaction.js
@@ -136,7 +136,9 @@ export default class Transaction {
       measure: makeMeasure(this),
       svgElements: new Set(),
       scriptsToExecute: new Map(),
-      mutationObserver: useObserver && new globalThis.window.MutationObserver(EMPTY.FUN),
+      mutationObserver: useObserver && new globalThis.window.MutationObserver(() => {
+        this.state.isDirty = true;
+      }),
     });
 
     this.tasks = /** @type {Function[]} */ (

--- a/packages/diffhtml/test/integration/basics.js
+++ b/packages/diffhtml/test/integration/basics.js
@@ -210,6 +210,16 @@ describe('Integration: Basics', function() {
       diff.release(documentElement);
       doc.close();
     });
+
+    it('will mark internal state as dirty if markup is modified outside of renders', function(cb) {
+      diff.innerHTML(this.fixture, '<div>Test</div>');
+      this.fixture.querySelector('div').innerHTML = 'External change';
+
+      setTimeout(() => {
+        assert.strictEqual(diff.Internals.StateCache.get(this.fixture).isDirty, true);
+        cb();
+      });
+    });
   });
 
   describe('DocumentFragment', function() {


### PR DESCRIPTION
A regression was reported by @nbianca where mutations to markup were not reflected internally. I had set `isDirty` to true in the [mutationobserver callback](https://github.com/tbranyen/diffhtml/pull/219/files#diff-a3690839a2f001661f7ed8f74ba455c44f0a0b9d100b5c7066f1b722cc3b6522R141). That was then removed when I added better support for [component top level rendering](https://github.com/tbranyen/diffhtml/commit/c9cb93688f194ba5f620550a0c5f657ded0ea3b9#diff-a3690839a2f001661f7ed8f74ba455c44f0a0b9d100b5c7066f1b722cc3b6522R144).

To fix this, I'm simply purging the mutationobserver records after every render since we only care about mutations when we aren't rendering (due to its synchronous nature).